### PR TITLE
Plug memory leaks detected when running the tutorial

### DIFF
--- a/src/cmd-wizard.c
+++ b/src/cmd-wizard.c
@@ -33,6 +33,7 @@
 #include "obj-pile.h"
 #include "obj-tval.h"
 #include "obj-util.h"
+#include "player-abilities.h"
 #include "player-calcs.h"
 #include "player-timed.h"
 #include "player-util.h"
@@ -1666,11 +1667,13 @@ void do_cmd_wiz_play_item(struct command *cmd)
 			struct object *prev = obj->prev;
 			struct object *next = obj->next;
 
-			/* Free slays, brands, and curses by hand. */
+			/* Free slays, brands, and abilities by hand. */
 			mem_free(obj->slays);
 			obj->slays = NULL;
 			mem_free(obj->brands);
 			obj->brands = NULL;
+			release_ability_list(obj->abilities);
+			obj->abilities = NULL;
 
 			object_copy(obj, orig_obj);
 			obj->prev = prev;
@@ -2118,11 +2121,15 @@ void do_cmd_wiz_reroll_item(struct command *cmd)
 		bitflag notice = obj->notice;
 		bool marked = obj->marked;
 
-		/* Free slays, brands, and curses on the old object by hand. */
+		/*
+		 * Free slays, brands, and abilities on the old object by hand.
+		 */
 		mem_free(obj->slays);
 		obj->slays = NULL;
 		mem_free(obj->brands);
 		obj->brands = NULL;
+		release_ability_list(obj->abilities);
+		obj->abilities = NULL;
 
 		/* Copy over; pile information needs to be restored. */
 		object_copy(obj, new);

--- a/src/game-world.c
+++ b/src/game-world.c
@@ -321,7 +321,7 @@ void update_flow(struct chunk *c, struct flow *flow, struct monster *mon)
 	struct loc next = flow->centre;
 	int y, x, d;
 	int value = 0;
-    struct queue *queue = q_new(c->height * c->width);
+	struct queue *queue = q_new(c->height * c->width);
 
 	/* Set all the grids to maximum */
 	for (y = 1; y < c->height - 1; y++) {
@@ -388,6 +388,8 @@ void update_flow(struct chunk *c, struct flow *flow, struct monster *mon)
 		}
 		value++;
 	}
+
+	q_free(queue);
 }
 
 /**

--- a/src/init.c
+++ b/src/init.c
@@ -994,6 +994,9 @@ static void cleanup_feat(void) {
 		string_free(f_info[idx].look_in_preposition);
 		string_free(f_info[idx].look_prefix);
 		string_free(f_info[idx].confused_msg);
+		string_free(f_info[idx].str_msg);
+		string_free(f_info[idx].fail_msg);
+		string_free(f_info[idx].dig_msg);
 		string_free(f_info[idx].die_msg);
 		string_free(f_info[idx].hurt_msg);
 		string_free(f_info[idx].run_msg);
@@ -1533,6 +1536,7 @@ static void cleanup_race(void)
 			item = item_next;
 		}
 		string_free((char *)r->name);
+		string_free((char *)r->desc);
 		mem_free(r);
 		r = next;
 	}
@@ -1685,7 +1689,10 @@ static void cleanup_house(void)
 
 	while (h) {
 		next = h->next;
-		mem_free((char *)h->name);
+		string_free((char *)h->name);
+		string_free((char *)h->alt_name);
+		string_free((char *)h->short_name);
+		string_free((char *)h->desc);
 		mem_free(h);
 		h = next;
 	}
@@ -1877,6 +1884,7 @@ static void cleanup_flavor(void)
 	f = flavors;
 	while(f) {
 		next = f->next;
+		string_free(f->text);
 		mem_free(f);
 		f = next;
 	}

--- a/src/mon-attack.c
+++ b/src/mon-attack.c
@@ -356,6 +356,7 @@ bool make_attack_normal(struct monster *mon, struct player *p)
 	int net_dam = 0;
 
 	char *act = NULL;
+	bool act_allocated = false;
 
 	/* Get the monster name (or "it") */
 	monster_desc(m_name, sizeof(m_name), mon, MDESC_STANDARD);
@@ -401,6 +402,7 @@ bool make_attack_normal(struct monster *mon, struct player *p)
 
 		/* Describe the attack method */
 		act = monster_blow_method_action(method, -1);
+		act_allocated = true;
 		do_cut = method->cut;
 		do_stun = method->stun;
 		do_prt = method->prt;
@@ -408,7 +410,11 @@ bool make_attack_normal(struct monster *mon, struct player *p)
 
 		/* Special case */
 		if (streq(method->name, "HIT") && streq(effect->name, "BATTER")) {
+			if (act_allocated) {
+				string_free(act);
+			}
 			act = (char *) "batters you";
+			act_allocated = false;
 		}
 
 		/* Hack -- assume all attacks are obvious */
@@ -449,6 +455,9 @@ bool make_attack_normal(struct monster *mon, struct player *p)
 			}
                 
 			msgt(sound_msg, "%s %s%s", m_name, act, punctuation);
+			if (act_allocated) {
+				string_free(act);
+			}
 		}
 
 		/* Perform the actual effect. */

--- a/src/mon-make.c
+++ b/src/mon-make.c
@@ -582,6 +582,9 @@ void wipe_mon_list(struct chunk *c, struct player *p)
 		/* Monster is gone from square */
 		square_set_mon(c, mon->grid, 0);
 
+		/* Free flow */
+		flow_free(c, &mon->flow);
+
 		/* Wipe the Monster */
 		memset(mon, 0, sizeof(struct monster));
 	}

--- a/src/obj-chest.c
+++ b/src/obj-chest.c
@@ -232,6 +232,7 @@ static void cleanup_chest_trap(void)
 		string_free(trap->name);
 		string_free(trap->msg);
 		string_free(trap->msg_save);
+		string_free(trap->msg_bad);
 		string_free(trap->msg_death);
 		free_effect(trap->effect);
 		trap = trap->next;

--- a/src/obj-init.c
+++ b/src/obj-init.c
@@ -683,6 +683,8 @@ static void cleanup_object_base(void)
 	int idx;
 	for (idx = 0; idx < TV_MAX; idx++) {
 		string_free(kb_info[idx].name);
+		mem_free(kb_info[idx].smith_slays);
+		mem_free(kb_info[idx].smith_brands);
 	}
 	mem_free(kb_info);
 }
@@ -1579,6 +1581,7 @@ static void cleanup_object(void)
 		string_free(kind->effect_msg);
 		mem_free(kind->brands);
 		mem_free(kind->slays);
+		release_ability_list(kind->abilities);
 		free_effect(kind->effect);
 		free_effect(kind->thrown_effect);
 		mem_free(kind->alloc);
@@ -2123,6 +2126,7 @@ static void cleanup_ego(void)
 		string_free(ego->name);
 		mem_free(ego->brands);
 		mem_free(ego->slays);
+		release_ability_list(ego->abilities);
 
 		poss = ego->poss_items;
 		while (poss) {
@@ -2491,6 +2495,7 @@ static void cleanup_artifact(void)
 		string_free(art->text);
 		mem_free(art->brands);
 		mem_free(art->slays);
+		release_ability_list(art->abilities);
 	}
 	mem_free(a_info);
 	mem_free(aup_info);

--- a/src/obj-pile.c
+++ b/src/obj-pile.c
@@ -37,6 +37,7 @@
 #include "obj-slays.h"
 #include "obj-tval.h"
 #include "obj-util.h"
+#include "player-abilities.h"
 #include "player-calcs.h"
 #include "player-history.h"
 #include "player-util.h"
@@ -293,6 +294,7 @@ void object_free(struct object *obj)
 {
 	mem_free(obj->slays);
 	mem_free(obj->brands);
+	release_ability_list(obj->abilities);
 	mem_free(obj);
 }
 
@@ -580,6 +582,7 @@ void object_wipe(struct object *obj)
 	/* Free slays and brands */
 	mem_free(obj->slays);
 	mem_free(obj->brands);
+	release_ability_list(obj->abilities);
 
 	/* Wipe the structure */
 	memset(obj, 0, sizeof(*obj));
@@ -601,6 +604,9 @@ void object_copy(struct object *dest, const struct object *src)
 	if (src->brands) {
 		dest->brands = mem_zalloc(z_info->brand_max * sizeof(bool));
 		memcpy(dest->brands, src->brands, z_info->brand_max * sizeof(bool));
+	}
+	if (src->abilities) {
+		dest->abilities = copy_ability_list(src->abilities);
 	}
 
 	/* Detach from any pile */

--- a/src/obj-smith.c
+++ b/src/obj-smith.c
@@ -1046,6 +1046,9 @@ void create_special(struct object *obj, struct ego_item *ego)
 	struct object_kind *kind = obj->kind;
 	if (obj->slays) mem_free(obj->slays);
 	if (obj->brands) mem_free(obj->brands);
+	if (obj->abilities) {
+		release_ability_list(obj->abilities);
+	}
 	create_base_object(kind, obj);
 
 	/* Set its 'special' type to reflect the chosen type */
@@ -1064,6 +1067,7 @@ void artefact_copy(struct artifact *a_dst, struct artifact *a_src)
 {
 	mem_free(a_dst->slays);
 	mem_free(a_dst->brands);
+	release_ability_list(a_dst->abilities);
 
 	/* Copy the structure */
 	memcpy(a_dst, a_src, sizeof(struct artifact));
@@ -1071,6 +1075,7 @@ void artefact_copy(struct artifact *a_dst, struct artifact *a_src)
 	a_dst->next = NULL;
 	a_dst->slays = NULL;
 	a_dst->brands = NULL;
+	a_dst->abilities = NULL;
 
 	if (a_src->slays) {
 		a_dst->slays = mem_zalloc(z_info->slay_max * sizeof(bool));
@@ -1079,6 +1084,9 @@ void artefact_copy(struct artifact *a_dst, struct artifact *a_src)
 	if (a_src->brands) {
 		a_dst->brands = mem_zalloc(z_info->brand_max * sizeof(bool));
 		memcpy(a_dst->brands, a_src->brands, z_info->brand_max * sizeof(bool));
+	}
+	if (a_src->abilities) {
+		a_dst->abilities = copy_ability_list(a_src->abilities);
 	}
 }
 
@@ -1339,6 +1347,7 @@ static void create_smithing_item(struct object *obj, struct smithing_cost *cost)
 		a_info = mem_realloc(a_info, z_info->a_max * sizeof(struct artifact));
 		aup_info = mem_realloc(aup_info, z_info->a_max * sizeof(*aup_info));
 
+		memset(&a_info[aidx], 0, sizeof(a_info[aidx]));
 		artefact_copy(&a_info[aidx], (struct artifact *) obj->artifact);
 		a_info[aidx].name = string_make(a_info[aidx].name);
 		player->self_made_arts++;

--- a/src/player-abilities.h
+++ b/src/player-abilities.h
@@ -56,6 +56,8 @@ bool player_has_prereq_abilities(struct player *p, struct ability *ability);
 int player_ability_cost(struct player *p, struct ability *ability);
 bool player_can_gain_ability(struct player *p, struct ability *ability);
 bool player_gain_ability(struct player *p, struct ability *ability);
+void release_ability_list(struct ability *head);
+struct ability *copy_ability_list(const struct ability *head);
 
 extern struct file_parser ability_parser;
 

--- a/src/player-timed.c
+++ b/src/player-timed.c
@@ -146,7 +146,6 @@ static enum parser_error parse_player_timed_change_increase(struct parser *p)
 {
 	struct timed_effect_data *t = parser_priv(p);
 	struct timed_change *current = t->increase;
-	struct timed_change *l = mem_zalloc(sizeof(*l));
 	assert(t);
 
 	/* Make a zero change structure if there isn't one */
@@ -174,7 +173,6 @@ static enum parser_error parse_player_timed_change_increase(struct parser *p)
 static enum parser_error parse_player_timed_change_decrease(struct parser *p)
 {
 	struct timed_effect_data *t = parser_priv(p);
-	struct timed_change *l = mem_zalloc(sizeof(*l));
 	assert(t);
 
 	t->decrease.max = parser_getint(p, "max");

--- a/src/player.c
+++ b/src/player.c
@@ -21,6 +21,7 @@
 #include "init.h"
 #include "obj-pile.h"
 #include "obj-util.h"
+#include "player-abilities.h"
 #include "player-birth.h"
 #include "player-calcs.h"
 #include "player-history.h"
@@ -377,6 +378,8 @@ void player_cleanup_members(struct player *p)
 	}
 	string_free(p->body.name);
 	string_free(p->history);
+	release_ability_list(p->abilities);
+	release_ability_list(p->item_abilities);
 }
 
 

--- a/src/songs.c
+++ b/src/songs.c
@@ -181,11 +181,15 @@ static void cleanup_song(void)
 		struct alt_song_desc *alt = s->alt_desc;
 		next = s->next;
 		while (alt) {
-			string_free(alt->desc);
+			struct alt_song_desc *alt_tgt = alt;
 			alt = alt->next;
+			string_free(alt_tgt->desc);
+			mem_free(alt_tgt);
 		}
 		free_effect(s->effect);
+		string_free(s->msg);
 		string_free(s->desc);
+		string_free(s->verb);
 		string_free(s->name);
 		mem_free(s);
 		s = next;

--- a/src/trap.c
+++ b/src/trap.c
@@ -495,6 +495,10 @@ static void cleanup_trap(void)
 		mem_free(trap_info[i].text);
 		string_free(trap_info[i].desc);
 		string_free(trap_info[i].msg);
+		string_free(trap_info[i].msg2);
+		string_free(trap_info[i].msg3);
+		string_free(trap_info[i].msg_vis);
+		string_free(trap_info[i].msg_silence);
 		string_free(trap_info[i].msg_good);
 		string_free(trap_info[i].msg_bad);
 		string_free(trap_info[i].msg_xtra);

--- a/src/ui-smith.c
+++ b/src/ui-smith.c
@@ -110,7 +110,10 @@ static bool pval_included = false;
 static void include_pval(struct object *obj)
 {
 	int i;
-	if (!pval_included) object_copy(smith_obj_backup, smith_obj);
+	if (!pval_included) {
+		object_wipe(smith_obj_backup);
+		object_copy(smith_obj_backup, smith_obj);
+	}
 	if (pval) {
 		if (ABS(obj->pval) <= 1) obj->pval *= pval;
 		for (i = 0; i < OBJ_MOD_MAX; i++) {
@@ -122,7 +125,10 @@ static void include_pval(struct object *obj)
 
 static void exclude_pval(struct object *obj)
 {
-	if (pval_included) object_copy(smith_obj, smith_obj_backup);
+	if (pval_included) {
+		object_wipe(smith_obj);
+		object_copy(smith_obj, smith_obj_backup);
+	}
 	pval_included = false;
 }
 
@@ -132,6 +138,7 @@ static void wipe_smithing_objects(void)
 	object_wipe(smith_obj_backup);
 	mem_free(smith_art->slays);
 	mem_free(smith_art->brands);
+	release_ability_list(smith_art->abilities);
 	memset(smith_art, 0, sizeof(*smith_art));
 }
 
@@ -141,6 +148,7 @@ static void reset_smithing_objects(struct object_kind *kind)
 	object_wipe(smith_obj_backup);
 	mem_free(smith_art->slays);
 	mem_free(smith_art->brands);
+	release_ability_list(smith_art->abilities);
 	memset(smith_art, 0, sizeof(*smith_art));
 	create_base_object(kind, smith_obj);
 	object_know(smith_obj);
@@ -406,6 +414,7 @@ static void sval_display(struct menu *menu, int oid, bool cursor, int row,
 	create_base_object(choice[oid], obj);
 	object_know(obj);
 	if (cursor) {
+		object_wipe(smith_obj_backup);
 		object_copy(smith_obj_backup, smith_obj);
 	}
 	include_pval(obj);
@@ -747,6 +756,7 @@ static void skill_display(struct menu *menu, int oid, bool cursor, int row,
 		if (!chosen) {
 			remove_ability(&smith_obj->abilities, choice[oid]);
 		}
+		object_wipe(smith_obj);
 		object_copy(smith_obj, &backup);
 		(void) smith_affordable(smith_obj, &current_cost);
 		exclude_pval(smith_obj);
@@ -1080,6 +1090,7 @@ static void numbers_set_validity(void)
 			/* Restore the object */
 			pval = old_pval;
 			exclude_pval(smith_obj);
+			object_wipe(smith_obj);
 			object_copy(smith_obj, &backup);
 		}
 	}


### PR DESCRIPTION
Resolves all of the leaks reported in https://github.com/NickMcConnell/NarSil/issues/164 except for the one caused by the multiple dice directives in object.txt for the horn of blasting.