### PR TITLE
Replace sprintf() with strnfmt()

### DIFF
--- a/src/ui-display.c
+++ b/src/ui-display.c
@@ -366,7 +366,7 @@ static void prt_song(int row, int col)
 
 	/* Show the slaying score */
 	if (slaying_bonus > 0) {
-		sprintf(buf, "+%d", slaying_bonus);
+		strnfmt(buf, sizeof(buf), "+%d", slaying_bonus);
 		if (song1 == slaying) {
 			c_put_str(COLOUR_L_BLUE, buf, row, col + 8);
 		} else if (song2 == slaying) {

--- a/src/ui-score.c
+++ b/src/ui-score.c
@@ -122,13 +122,15 @@ void display_single_score(const struct high_score *score, int row, int place,
 	if ((*when == '@') && strlen(when) == 9) {
 		char month[4];
 
-		sprintf(month,"%.2s", when + 5);
+		strnfmt(month, sizeof(month), "%.2s", when + 5);
 		atomonth(atoi(month), month, sizeof(month));
 
 		if (*(when + 7) == '0') {
-			sprintf(tmp_val, "%.1s %.3s %.4s", when + 8, month, when + 1);
+			strnfmt(tmp_val, sizeof(tmp_val), "%.1s %.3s %.4s",
+				when + 8, month, when + 1);
 		} else {
-			sprintf(tmp_val, "%.2s %.3s %.4s", when + 7, month, when + 1);
+			strnfmt(tmp_val, sizeof(tmp_val), "%.2s %.3s %.4s",
+				when + 7, month, when + 1);
 		}	
 		when = tmp_val;
 	}


### PR DESCRIPTION
Avoids deprecation warnings with clang 14.0.0 on macOS 12.6.5.