### PR TITLE
Avoid more warnings with clang on macOS

### DIFF
--- a/src/cmd-cave.c
+++ b/src/cmd-cave.c
@@ -818,7 +818,7 @@ static bool twall(struct loc grid)
 /**
  * Print a message when the player doesn't have the required digger for terrain.
  */
-void fail_message(struct feature *terrain, char *name)
+static void fail_message(struct feature *terrain, char *name)
 {
 	char buf[1024] = "\0";
 

--- a/src/cmd-obj.c
+++ b/src/cmd-obj.c
@@ -252,7 +252,6 @@ void do_cmd_wield(struct command *cmd)
 
 		/* Warn about dropping item in left hand */
 		if (!object_is_carried(player, obj) && pack_is_full()) {
-			const char *thing = shield ? "shield" : "off-hand weapon";
 			/* Flush input */
 			event_signal(EVENT_INPUT_FLUSH);
 

--- a/src/game-world.c
+++ b/src/game-world.c
@@ -561,7 +561,7 @@ void process_world(struct chunk *c)
 /**
  * Housekeeping after the processing monsters but before processing the player
  */
-void pre_process_player(void)
+static void pre_process_player(void)
 {
 	int i;
 

--- a/src/load.c
+++ b/src/load.c
@@ -50,13 +50,6 @@
 #include "ui-term.h"
 
 /**
- * Setting this to 1 and recompiling gives a chance to recover a savefile 
- * where the object list has become corrupted.  Don't forget to reset to 0
- * and recompile again as soon as the savefile is viable again.
- */
-#define OBJ_RECOVER 0
-
-/**
  * Dungeon constants
  */
 static uint8_t square_size = 0;

--- a/src/obj-gear.c
+++ b/src/obj-gear.c
@@ -878,15 +878,15 @@ void inven_wield(struct object *obj, int slot)
 
 	/* Handle split objects; messy, but avoids re-ID and ensuing messages */
 	if (split) {
-		int num = obj->number;
+		int snum = obj->number;
 		int oidx = obj->oidx;
 		struct object *prev = obj->prev, *next = obj->next;
 		struct loc grid = obj->grid;
-		assert(num);
+		assert(snum);
 		object_copy(obj, wielded);
 		obj->prev = prev;
 		obj->next = next;
-		obj->number = num;
+		obj->number = snum;
 		obj->oidx = oidx;
 		obj->grid = grid;
 	}


### PR DESCRIPTION
Those are for missing prototypes, shadowing of local variables, and unused preprocessor directives.