### PR TITLE
Avoid crash due to erroneous free in make_attack_normal()

### DIFF
--- a/src/mon-attack.c
+++ b/src/mon-attack.c
@@ -450,7 +450,11 @@ bool make_attack_normal(struct monster *mon, struct player *p)
 				/* Remember that the monster can do this */
 				if (monster_is_visible(mon)) {
 					rf_on(lore->flags, RF_CHARGE);
+					if (act_allocated) {
+						string_free(act);
+					}
 					act = (char *) "charges you";
+					act_allocated = false;
                 }
 			}
                 


### PR DESCRIPTION
Potential for crash was introduced by f7f0e27a2c984fe679bbef302eda0e2803a6aed4 .  Resolves https://github.com/NickMcConnell/NarSil/issues/192 .