### PR TITLE
Better match Sil 1.3's alloc_object()

### DIFF
--- a/src/gen-cave.c
+++ b/src/gen-cave.c
@@ -1079,7 +1079,8 @@ struct chunk *cave_gen(struct player *p)
 	if ((c->depth >= 10) && one_in_(2)) {
 		rubble_gen += blocks * blocks * 2;
 	}
-	alloc_object(c, SET_BOTH, TYP_RUBBLE, rubble_gen, false);
+	alloc_object(c, SET_BOTH, TYP_RUBBLE, rubble_gen, c->depth,
+		ORIGIN_FLOOR);
 
 	/* Place the player */
 	new_player_spot(c, p);
@@ -1104,7 +1105,8 @@ struct chunk *cave_gen(struct player *p)
 	/* Put some objects in rooms */
 	obj_room_gen = 3 * mon_gen / 4;
 	if (obj_room_gen > 0) {
-		alloc_object(c, SET_ROOM, TYP_OBJECT, obj_room_gen, false);
+		alloc_object(c, SET_ROOM, TYP_OBJECT, obj_room_gen, c->depth,
+			ORIGIN_FLOOR);
 	}
 	
     /* Place the traps */

--- a/src/gen-util.c
+++ b/src/gen-util.c
@@ -725,25 +725,27 @@ void place_traps(struct chunk *c)
 }
 
 /**
- * Allocates a single random object in the dungeon.
+ * Allocates zero or more random objects in the dungeon.
  * \param c the current chunk
  * \param set where the entity is placed (corridor, room or either)
  * \param typ what is placed (rubble, trap, gold, item)
+ * \param num is the number of objects to allocate
  * \param depth generation depth
  * \param origin item origin (if appropriate)
+ * \return the number of objects actually placed
  *
  * 'set' controls where the object is placed (corridor, room, either).
  * 'typ' conrols the kind of object (rubble, trap, gold, item).
  */
-bool alloc_object(struct chunk *c, int set, int typ, int depth,
+int alloc_object(struct chunk *c, int set, int typ, int num, int depth,
 						 uint8_t origin)
 {
-	bool placed = false;
+	int nrem = num;
 	int *state = cave_find_init(loc(1, 1),
 		loc(c->width - 2, c->height - 2));
 	struct loc grid;
 
-	while (!placed && cave_find_get_grid(&grid, state)) {
+	while (nrem > 0 && cave_find_get_grid(&grid, state)) {
 		/*
 		 * If we're ok with a corridor and we're in one, we're done.
 		 * If we are ok with a room and we're in one, we're done
@@ -760,12 +762,12 @@ bool alloc_object(struct chunk *c, int set, int typ, int depth,
 				place_object(c, grid, depth, false, false, origin, 0);
 				break;
 			}
-			placed = true;
+			--nrem;
 		}
 	}
 
 	mem_free(state);
-	return placed;
+	return num - nrem;
 }
 
 /**

--- a/src/generate.h
+++ b/src/generate.h
@@ -243,7 +243,8 @@ void place_closed_door(struct chunk *c, struct loc grid);
 void place_random_door(struct chunk *c, struct loc grid);
 void place_forge(struct chunk *c, struct loc grid);
 void alloc_stairs(struct chunk *c, int feat, int num);
-bool alloc_object(struct chunk *c, int set, int typ, int depth, uint8_t origin);
+int alloc_object(struct chunk *c, int set, int typ, int num, int depth,
+	uint8_t origin);
 struct room_profile lookup_room_profile(const char *name);
 void uncreate_artifacts(struct chunk *c);
 void chunk_validate_objects(struct chunk *c);


### PR DESCRIPTION
Now can allocate more than one object (was passing the number of objects as the depth) and the origin is properly set by callers.  Helps address MITZE's and Bill Peterson's reports here, http://angband.oook.cz/forum/showpost.php?p=160610&postcount=59 , and here, http://angband.oook.cz/forum/showpost.php?p=160628&postcount=60 .

The number of floor objects and rubble may still need tweaking to match Sil 1.3: alloc_object() here will only fail to allocate the requested number if the number of grids in the dungeon matching the placement criteria is less than the requested number of objects while Sil 1.3's version has a stochastic chance of failure to place an object.