### PR TITLE
Allow Curse Breaking for removing and throwing besides dropping

### DIFF
--- a/src/cmd-obj.c
+++ b/src/cmd-obj.c
@@ -183,6 +183,11 @@ void do_cmd_takeoff(struct command *cmd)
 			/* Choice */ USE_EQUIP) != CMD_OK)
 		return;
 
+	/* Cannot take off stickied items without special measures. */
+	if (handle_stickied_removal(player, obj)) {
+		return;
+	}
+
 	inven_takeoff(obj);
 	combine_pack(player);
 	pack_overflow(obj);
@@ -361,6 +366,11 @@ void do_cmd_wield(struct command *cmd)
 		if (!get_check(format("Really take off %s? ", o_name))) return;
 	}
 
+	/* Replacing an equipped cursed item requires special measures. */
+	if (handle_stickied_removal(player, equip_obj)) {
+		return;
+	}
+
 	inven_takeoff(equip_obj);
 	inven_wield(obj, slot);
 }
@@ -381,19 +391,9 @@ void do_cmd_drop(struct command *cmd)
 			/* Choice */ USE_EQUIP | USE_INVEN | USE_QUIVER) != CMD_OK)
 		return;
 
-	/* Cannot remove stickied items */
-	if (object_is_equipped(player->body, obj) && !obj_can_takeoff(obj)) {
-		if (player_active_ability(player, "Curse Breaking")) {
-			/* Message */
-			msg("With a great strength of will, you break the curse!");
-
-			/* Uncurse the object */
-			uncurse_object(obj);
-		} else {
-			/* Oops */
-			msg("You cannot bear to part with it.");
-			return;
-		}
+	/* Cannot remove equipped stickied items without special measures. */
+	if (handle_stickied_removal(player, obj)) {
+		return;
 	}
 
 	if (cmd_get_quantity(cmd, "quantity", &amt, obj->number) != CMD_OK)

--- a/src/obj-gear.c
+++ b/src/obj-gear.c
@@ -591,6 +591,38 @@ struct object *gear_object_for_use(struct player *p, struct object *obj,
 }
 
 /**
+ * Handle curse checks and messaging for dropping, removing or throwing an
+ * item that may be equipped and may be cursed.
+ *
+ * \param p is the player trying to drop, remove, or throw the object in
+ * question.
+ * \param obj is the object the player is trying to drop, remove, or throw.
+ * \param return true if the object is equipped but can not be dropped, removed,
+ * or thrown (it is cursed and the player has no ability to counteract the
+ * stickiness).  Return false if the object can be dropped, removed, or thrown.
+ */
+bool handle_stickied_removal(struct player *p, struct object *obj)
+{
+	if (!object_is_equipped(player->body, obj)
+			|| !obj_has_flag(obj, OF_CURSED)) {
+		/*
+		 * There's no problem and no messaging needed if the item is
+		 * not equipped or is equipped but not cursed.
+		 */
+		return false;
+	}
+
+	if (player_active_ability(player, "Curse Breaking")) {
+		msg("With a great strength of will, you break the curse!");
+		uncurse_object(obj);
+		return false;
+	}
+
+	msg("You cannot bear to part with it.");
+	return true;
+}
+
+/**
  * Calculate how much of an item is can be carried in the inventory or quiver.
  */
 int inven_carry_num(const struct player *p, const struct object *obj)

--- a/src/obj-gear.h
+++ b/src/obj-gear.h
@@ -54,6 +54,7 @@ struct object *gear_last_item(struct player *p);
 void gear_insert_end(struct player *p, struct object *obj);
 struct object *gear_object_for_use(struct player *p, struct object *obj,
 	int num, bool message, bool *none_left);
+bool handle_stickied_removal(struct player *p, struct object *obj);
 int inven_carry_num(const struct player *p, const struct object *obj);
 bool inven_carry_okay(const struct object *obj);
 void inven_item_charges(struct object *obj);

--- a/src/obj-util.c
+++ b/src/obj-util.c
@@ -575,10 +575,11 @@ bool obj_can_refuel(const struct object *obj)
 	return false;
 }
 
-/* Can only take off non-cursed items */
+/* Can only take off cursed items in special circumstances */
 bool obj_can_takeoff(const struct object *obj)
 {
-	return !obj_has_flag(obj, OF_CURSED);
+	return !obj_has_flag(obj, OF_CURSED)
+		|| player_active_ability(player, "Curse Breaking");
 }
 
 /* Can only put on wieldable items */

--- a/src/player-attack.c
+++ b/src/player-attack.c
@@ -1585,6 +1585,9 @@ void do_cmd_throw(struct command *cmd) {
 
 	if (object_is_equipped(player->body, obj)) {
 		assert(obj_can_takeoff(obj) && tval_is_melee_weapon(obj));
+		if (handle_stickied_removal(player, obj)) {
+			return;
+		}
 		inven_takeoff(obj);
 	}
 


### PR DESCRIPTION
The removing part matches what Sil 1.3 allows.  Resolves https://github.com/NickMcConnell/NarSil/issues/60 .  The throwing part is an extension since NarSil allows throwing the equipped weapon but Sil 1.3 does not.