### PR TITLE
Fix birth display issues

### DIFF
--- a/src/player-birth.c
+++ b/src/player-birth.c
@@ -765,7 +765,6 @@ void do_cmd_choose_race(struct command *cmd)
 	cmd_get_arg_choice(cmd, "choice", &choice);
 	player_generate(player, player_id2race(choice), NULL, NULL, false);
 
-	reset_stats(stats, points_spent, points_inc, &points_left, false);
 	init_skills(true, true);
 }
 
@@ -775,7 +774,6 @@ void do_cmd_choose_house(struct command *cmd)
 	cmd_get_arg_choice(cmd, "choice", &choice);
 	player_generate(player, NULL, player_house_from_count(choice), NULL, false);
 
-	reset_stats(stats, points_spent, points_inc, &points_left, false);
 	init_skills(true, true);
 }
 
@@ -785,7 +783,6 @@ void do_cmd_choose_sex(struct command *cmd)
 	cmd_get_arg_choice(cmd, "choice", &choice);
 	player_generate(player, NULL, NULL, player_id2sex(choice), false);
 
-	reset_stats(stats, points_spent, points_inc, &points_left, false);
 	init_skills(true, true);
 }
 

--- a/src/player-calcs.c
+++ b/src/player-calcs.c
@@ -934,6 +934,11 @@ void calc_bonuses(struct player *p, struct player_state *state, bool known_only,
 	for (i = 0; i < STAT_MAX; i++) {
 		state->stat_use[i] = p->stat_base[i] + state->stat_equip_mod[i]
 			+ p->stat_drain[i] + state->stat_misc_mod[i];
+		/* Hack for correct calculations during pre-birth */
+		if (!p->body.name) {
+			state->stat_use[i] += p->race->stat_adj[i]
+				+ p->house->stat_adj[i];
+		}
 
 		/* Cap to -9 and 20 */
 		state->stat_use[i] = MIN(state->stat_use[i], BASE_STAT_MAX);

--- a/src/ui-birth.c
+++ b/src/ui-birth.c
@@ -123,6 +123,12 @@ static enum birth_stage textui_birth_quickstart(void)
 		
 		if (ke.code == 'N' || ke.code == 'n') {
 			cmdq_push(CMD_BIRTH_RESET);
+			/*
+			 * If the player rejects the quickstart, also reset
+			 * the stat buy that was used for the previous
+			 * character.
+			 */
+			cmdq_push(CMD_RESET_STATS);
 			next = BIRTH_RACE_CHOICE;
 		} else if (ke.code == KTRL('X')) {
 			quit(NULL);

--- a/src/ui-player.c
+++ b/src/ui-player.c
@@ -149,13 +149,7 @@ void display_player_stat_info(void)
 			put_str(stat_names[i], row+i, col);
 
 		/* Resulting "modified" maximum value */
-		if (!player->body.name) {
-			/* Hack to display correct pre-birth stats */
-			strnfmt(buf, sizeof(buf), "%2d", player->state.stat_use[i] +
-					player->race->stat_adj[i] + player->house->stat_adj[i]);
-		} else {
-			strnfmt(buf, sizeof(buf), "%2d", player->state.stat_use[i]);
-		}
+		strnfmt(buf, sizeof(buf), "%2d", player->state.stat_use[i]);
 		if (player->stat_drain[i] < 0)
 			c_put_str(COLOUR_YELLOW, buf, row + i, col + 5);
 		else


### PR DESCRIPTION
Resolves https://github.com/NickMcConnell/NarSil/issues/181 and https://github.com/NickMcConnell/NarSil/issues/124 .  Moves hack for pre-birth stat calculations from ui-player.c to player-calcs.c so the melee, defense, hp, voice, and skill calculations are correct as well.  Differs from Sil 1.3 in that backing out from the stat buy screen retains the current selections from that screen:  that's for consistency with backing out of the other choices where the last choice made is remembered.