### PR TITLE
Protect ranged_helper() against undefined behavior if target is self

### DIFF
--- a/src/player-attack.c
+++ b/src/player-attack.c
@@ -1182,7 +1182,8 @@ static void ranged_helper(struct player *p,	struct object *obj, int dir,
 		bool hit_wall = false;
 		bool ghost_arrow = false;
 		int missed_monsters = 0;
-		struct loc final_grid = path_g[path_n - 1];
+		struct loc final_grid = (path_n > 0) ?
+			path_g[path_n - 1] : p->grid;
 
 		/* Abort any later shot(s) if there is no target on the trajectory */
 		if ((shot > 0) && !targets_remaining) break;


### PR DESCRIPTION
Resolves https://github.com/NickMcConnell/NarSil/issues/232 .

May want to check if Sil 1.3's behavior should be adopted of not being able to target the player's grid or to see if there's something, perhaps in repeating the last command or targeting the most recent target which has since died or moved out of sight, which causes the target to be the player's grid when the player isn't expecting that.  For the latter, that may have a tie to https://github.com/NickMcConnell/NarSil/issues/201 .