### PR TITLE
Timed stat boosts do not require special handling when ending

### DIFF
--- a/src/player-timed.c
+++ b/src/player-timed.c
@@ -486,26 +486,6 @@ static void player_timed_end_effect(int idx)
 			player->upkeep->redraw |= PR_MAP;
 			break;
 		}
-		case TMD_STR: {
-			effect_simple(EF_DRAIN_STAT, source_none(), "3", STAT_STR, 0, 0,
-						  NULL);
-			break;
-		}
-		case TMD_DEX: {
-			effect_simple(EF_DRAIN_STAT, source_none(), "3", STAT_DEX, 0, 0,
-						  NULL);
-			break;
-		}
-		case TMD_CON: {
-			effect_simple(EF_DRAIN_STAT, source_none(), "3", STAT_CON, 0, 0,
-						  NULL);
-			break;
-		}
-		case TMD_GRA: {
-			effect_simple(EF_DRAIN_STAT, source_none(), "3", STAT_GRA, 0, 0,
-						  NULL);
-			break;
-		}
 		default: break;
 	}
 }


### PR DESCRIPTION
Resolves part of https://github.com/NickMcConnell/NarSil/issues/90 : stat potions have awkward messaging when they lapse.