### PR TITLE
Have REMOVE_CURSE effect handler always return true

### DIFF
--- a/src/effect-handler-general.c
+++ b/src/effect-handler-general.c
@@ -332,7 +332,7 @@ bool effect_handler_RESTORE_MANA(effect_handler_context_t *context)
 }
 
 /**
- * Attempt to uncurse an object
+ * Uncurse all equipped objects
  */
 bool effect_handler_REMOVE_CURSE(effect_handler_context_t *context)
 {
@@ -349,14 +349,14 @@ bool effect_handler_REMOVE_CURSE(effect_handler_context_t *context)
 		/* Uncurse the object */
 		uncurse_object(obj);
 		removed = true;
-		context->ident = true;
 	}
 
 	if (removed) {
+		context->ident = true;
 		msg("You feel sanctified.");
 	}
 
-	return context->ident;
+	return true;
 }
 
 /**


### PR DESCRIPTION
In other words, the effect did happen, but may have done nothing.  A staff of sanctity will now be marked as {tried} when used without a cursed item equipped.  That's part of https://github.com/NickMcConnell/NarSil/issues/90 .