### PR TITLE
Better match Sil 1.3's messaging for the staff of warding

### DIFF
--- a/lib/gamedata/object.txt
+++ b/lib/gamedata/object.txt
@@ -1583,6 +1583,7 @@ desc:It causes fear in all monsters in line of sight.
 #defence:0:0d0
 #alloc:7:2
 #charges:2d2
+#msg:Your mind turns inward.
 #effect:SELF_KNOWLEDGE
 #desc:It lets you know all of your abilities.
 
@@ -1598,6 +1599,7 @@ attack:0:0d0
 defence:0:0d0
 alloc:11:3
 charges:2d2
+msg:The base of the staff glows an intense green...
 effect:GLYPH:WARDING
 desc:It can be used to create glyphs of warding, which your opponents
 desc: have difficulty crossing.

--- a/src/effect-handler-general.c
+++ b/src/effect-handler-general.c
@@ -241,7 +241,7 @@ bool effect_handler_GLYPH(effect_handler_context_t *context)
 
 	/* See if the effect works */
 	if (!square_istrappable(cave, player->grid)) {
-		msg("There is no clear floor on which to cast the spell.");
+		msg("You cannot draw a glyph without a clean expanse of floor.");
 		return false;
 	}
 
@@ -250,6 +250,7 @@ bool effect_handler_GLYPH(effect_handler_context_t *context)
 		push_object(player->grid);
 
 	/* Create a glyph */
+	msg("You trace out a glyph of warding upon the floor.");
 	square_add_glyph(cave, player->grid, context->subtype);
 
 	return true;


### PR DESCRIPTION
Resolves the part of https://github.com/NickMcConnell/NarSil/issues/90 related to lack of messages for the staff of warding.  Also adds a commented out message for the staff of self knowledge to match what's in Sil 1.3's code for it.