### PR TITLE
Only ID herbs of sustenance and emptiness if the grade for TMD_FOOD changes

### DIFF
--- a/lib/gamedata/object.txt
+++ b/lib/gamedata/object.txt
@@ -2285,7 +2285,7 @@ attack:0:0d0
 defence:0:0d0
 alloc:5:2
 alloc:15:1
-effect:NOURISH:INC_BY
+effect:NOURISH:INC_BY:0:1
 dice:2000
 desc:It provides nourishment for about 2000 turns
 desc: under normal conditions. 
@@ -2374,7 +2374,7 @@ cost:0
 attack:0:0d0
 defence:0:0d0
 alloc:4:3
-effect:NOURISH:DEC_BY
+effect:NOURISH:DEC_BY:0:1
 dice:1000
 desc:It makes you more hungry (by 1,000 turns under normal conditions). 
 

--- a/src/effect-handler-general.c
+++ b/src/effect-handler-general.c
@@ -162,6 +162,7 @@ static bool item_tester_unknown(const struct object *obj)
  */
 bool effect_handler_NOURISH(effect_handler_context_t *context)
 {
+	const char *old_grade = player_get_timed_grade(player, TMD_FOOD);
 	int amount = effect_calculate_value(context);
 	if (context->subtype == 0) {
 		/* Increase food level by amount */
@@ -172,7 +173,17 @@ bool effect_handler_NOURISH(effect_handler_context_t *context)
 	} else {
 		return false;
 	}
-	context->ident = true;
+	/*
+	 * If the effect's other parameter is nonzero, only identify if the
+	 * timed grade changed.  Otherwise, always identify.
+	 */
+	if (context->other) {
+		if (old_grade != player_get_timed_grade(player, TMD_FOOD)) {
+			context->ident = true;
+		}
+	} else {
+		context->ident = true;
+	}
 	return true;
 }
 

--- a/src/player-timed.c
+++ b/src/player-timed.c
@@ -491,6 +491,29 @@ static void player_timed_end_effect(int idx)
 }
 
 /**
+ * Return the name of the current grade of a timed effect on a player.
+ *
+ * \param p is the player to query.
+ * \param idx is the index of the timed effect.
+ * \return NULL if the timed effect is not currently active; otherwise return
+ * the name of the currently active grade for the timed effect.  The returned
+ * string should not be freed.
+ */
+const char *player_get_timed_grade(const struct player *p, int idx)
+{
+	const struct timed_grade *grade;
+
+	if (!p->timed[idx]) {
+		return NULL;
+	}
+	grade = timed_effects[idx].grade;
+	while (p->timed[idx] > grade->max) {
+		grade = grade->next;
+	}
+	return grade->name;
+}
+
+/**
  * Return true if the player timed effect matches the given string
  */
 bool player_timed_grade_eq(const struct player *p, int idx, const char *match)

--- a/src/player-timed.h
+++ b/src/player-timed.h
@@ -96,6 +96,7 @@ extern struct timed_effect_data timed_effects[TMD_MAX];
 
 int timed_name_to_idx(const char *name);
 int player_timed_decrement_amount(struct player *p, int idx);
+const char *player_get_timed_grade(const struct player *p, int idx);
 bool player_timed_grade_eq(const struct player *p, int idx, const char *match);
 bool player_timed_grade_gt(const struct player *p, int idx, const char *match);
 bool player_timed_grade_lt(const struct player *p, int idx, const char *match);


### PR DESCRIPTION
Addresses part of https://github.com/NickMcConnell/NarSil/issues/90 .

While this matches Sil 1.3's behavior for those herbs, it feels like unnecessary frustration for the player since NarSil displays a % full indicator on the status line:  if the player watches that indicator he or she can see that the herb has an effect even if the grade doesn't change. If you do want to apply this as is, I'd also make the change that only the name of the grade for TMD_FOOD is shown on the status bar.