### PR TITLE
Have square_iswall() return true for rubble

### DIFF
--- a/src/cave-square.c
+++ b/src/cave-square.c
@@ -328,7 +328,7 @@ bool square_iswall(struct chunk *c, struct loc grid)
 {
 	int feat = square(c, grid)->feat;
 	return tf_has(f_info[feat].flags, TF_DOOR_CLOSED) ||
-		tf_has(f_info[feat].flags, TF_WALL);
+		tf_has(f_info[feat].flags, TF_ROCK);
 }
 
 /**


### PR DESCRIPTION
That fixes a regression introduced by https://github.com/NickMcConnell/NarSil/commit/e53929fac8e8950d6a815716168085a90a6ee9fc .