### PR TITLE
Only signal that the map is visible if cave is not NULL

### DIFF
--- a/src/ui-output.c
+++ b/src/ui-output.c
@@ -441,7 +441,7 @@ bool textui_map_is_visible(void)
 {
 	/* Special case for post-death dungeon viewing */
 	if (player->is_dead) return true;
-	return (screen_save_depth == 0);
+	return (cave && screen_save_depth == 0);
 }
 
 /**


### PR DESCRIPTION
Fixes an assertion reported in https://github.com/NickMcConnell/NarSil/issues/16 while displaying the throne room poem.