### PR TITLE
Drop the percent full indicator on the status line

### DIFF
--- a/src/ui-display.c
+++ b/src/ui-display.c
@@ -977,13 +977,6 @@ static size_t prt_tmd(int row, int col)
 				c_put_str(grade->color, meter, row, col + len);
 				len += strlen(meter) + 1;
 			}
-
-			/* Food meter */
-			if (i == TMD_FOOD) {
-				char *meter = format("%d %%", player->timed[i] / 100);
-				c_put_str(grade->color, meter, row, col + len);
-				len += strlen(meter) + 1;
-			}
 		}
 	}
 


### PR DESCRIPTION
That's for consistency with how the herbs of sustenance and emptiness are only identified if the grade for TMD_FOOD changes.