### PR TITLE
Like Sil, use the same message for the SLOW monster spell if seen or unseen

### DIFF
--- a/lib/gamedata/monster_spell.txt
+++ b/lib/gamedata/monster_spell.txt
@@ -288,6 +288,7 @@ effect:TIMED_INC_NO_RES:SLOW
 dice:2d4
 lore:slow
 message-vis:{name} whispers of fading and decay.
+message-invis:{name} whispers of fading and decay.
 message-save:You resist.
 
 name:SNG_BIND

--- a/src/mon-spell.c
+++ b/src/mon-spell.c
@@ -125,6 +125,14 @@ static void spell_message(struct monster *mon,
 					in_cursor = level->blind_message;
 				}
 			}
+			if (in_cursor == NULL) {
+				msg("No message-invis for monster spell %d "
+					"cast by %s%s.  Please report this "
+					"bug.", (int)spell->index,
+					(silence) ? "silenced " : "",
+					mon->race->name);
+				return;
+			}
 		} else if (in_cursor[0] == '\0') {
 			return;
 		}
@@ -145,6 +153,14 @@ static void spell_message(struct monster *mon,
 				} else {
 					in_cursor = level->message;
 				}
+			}
+			if (in_cursor == NULL) {
+				msg("No message-vis for monster spell %d "
+					"cast by %s%s.  Please report this "
+					"bug.", (int)spell->index,
+					(silence) ? "silenced " : "",
+					mon->race->name);
+				return;
 			}
 		} else if (in_cursor[0] == '\0') {
 			return;


### PR DESCRIPTION
Resolves https://github.com/NickMcConnell/NarSil/issues/299 .  Also add protection in spell_message() for cases where a spell does not specify a message for the seen or unseen case.