### PR TITLE
Combat rolls: limit use of race pointers to players and visible monsters

### DIFF
--- a/src/ui-combat.c
+++ b/src/ui-combat.c
@@ -131,7 +131,8 @@ void update_combat_rolls_attack(game_event_type type, game_event_data *data,
 				attacker.which.trap->kind->d_char;
 			combat_rolls[0][combat_number].attacker_attr =
 				attacker.which.trap->kind->d_attr;
-		} else if (vis || (attacker.what == SRC_PLAYER)) {
+		} else if ((vis && (attacker.what == SRC_MONSTER))
+				|| (attacker.what == SRC_PLAYER)) {
 			combat_rolls[0][combat_number].attacker_char = race1->d_char;
 
 			if (player->timed[TMD_RAGE] && (attacker.what != SRC_PLAYER)) {
@@ -148,7 +149,8 @@ void update_combat_rolls_attack(game_event_type type, game_event_data *data,
 			/* Hack for Iron Crown */
 			combat_rolls[0][combat_number].defender_char = ']';
 			combat_rolls[0][combat_number].defender_attr = COLOUR_L_DARK;
-		} else if (vis || (defender.what == SRC_PLAYER)) {
+		} else if ((vis && (defender.what == SRC_MONSTER))
+				|| (defender.what == SRC_PLAYER)) {
 			combat_rolls[0][combat_number].defender_char = race2->d_char;
 			
 			if (player->timed[TMD_RAGE] && (defender.what != SRC_PLAYER)) {


### PR DESCRIPTION
Resolves https://github.com/NickMcConnell/NarSil/issues/311 .

For chest traps, Sil 1.3 sets the character and attribute for the combat rolls window to be what's used for the chest (see cmd2.c:703-704).  To emulate that in NarSil, would need to get the struct object pointer for the chest in to update_combat_rolls().  One way would to that would be for struct source to store both a chest_trap and object pointer for SRC_CHEST_TRAP (and update source_chest_trap() to support setting both).  That is not done here.