### PR TITLE
Object messages: add an article or number before a full name when needed

### DIFF
--- a/src/cmd-obj.c
+++ b/src/cmd-obj.c
@@ -230,7 +230,8 @@ void do_cmd_wield(struct command *cmd)
 		(player->upkeep->total_weight + obj->weight >
 		 weight_limit(player->state)* 3 / 2)) {
 		/* Describe it */
-		object_desc(o_name, sizeof(o_name), obj, ODESC_FULL, player);
+		object_desc(o_name, sizeof(o_name), obj,
+			ODESC_PREFIX | ODESC_FULL, player);
 
 		if (obj->kind) msg("You cannot lift %s.", o_name);
 

--- a/src/obj-knowledge.c
+++ b/src/obj-knowledge.c
@@ -637,7 +637,8 @@ void ident_on_wield(struct player *p, struct object *obj)
 		ident(obj);
 
 		/* Full object description */
-		object_desc(o_name, sizeof(o_name), obj, ODESC_FULL, p);
+		object_desc(o_name, sizeof(o_name), obj,
+			ODESC_PREFIX | ODESC_FULL, p);
 
 		/* Print the messages */
 		msg("You recognize it as %s.", o_name);
@@ -685,7 +686,8 @@ void ident_flag(struct player *p, int flag)
 			ident(obj);
 
 			/* Full object description */
-			object_desc(o_full_name, sizeof(o_full_name), obj, ODESC_FULL, p);
+			object_desc(o_full_name, sizeof(o_full_name), obj,
+				ODESC_PREFIX | ODESC_FULL, p);
 
 			/* Print the message */
 			msg("You realize that it is %s.", o_full_name);
@@ -736,7 +738,8 @@ void ident_element(struct player *p, int element)
 			ident(obj);
 
 			/* Full object description */
-			object_desc(o_full_name, sizeof(o_full_name), obj, ODESC_FULL, p);
+			object_desc(o_full_name, sizeof(o_full_name), obj,
+				ODESC_PREFIX | ODESC_FULL, p);
 
 			/* Print the message */
 			msg("You realize that it is %s.", o_full_name);
@@ -783,7 +786,8 @@ void ident_passive(struct player *p)
 			ident(obj);
 
 			/* Full object description */
-			object_desc(o_full_name, sizeof(o_full_name), obj, ODESC_FULL, p);
+			object_desc(o_full_name, sizeof(o_full_name), obj,
+				ODESC_PREFIX | ODESC_FULL, p);
 
 			/* Print the message */
 			msg("You realize that your %s is %s.", o_short_name,
@@ -824,7 +828,8 @@ void ident_see_invisible(const struct monster *mon, struct player *p)
 			ident(obj);
 
 			/* Full object description */
-			object_desc(o_full_name, sizeof(o_full_name), obj, ODESC_FULL, p);
+			object_desc(o_full_name, sizeof(o_full_name), obj,
+				ODESC_PREFIX | ODESC_FULL, p);
 			
 			/* Print the messages */
 			msg("You notice that you can see %s very clearly.", m_name);
@@ -861,7 +866,8 @@ void ident_haunted(struct player *p)
 			ident(obj);
 
 			/* Full object description */
-			object_desc(o_full_name, sizeof(o_full_name), obj, ODESC_FULL, p);
+			object_desc(o_full_name, sizeof(o_full_name), obj,
+				ODESC_PREFIX | ODESC_FULL, p);
 			
 			/* Print the messages */
 			msg("You notice that wraiths are being drawn to you.");
@@ -898,7 +904,8 @@ void ident_cowardice(struct player *p)
 			ident(obj);
 
 			/* Full object description */
-			object_desc(o_full_name, sizeof(o_full_name), obj, ODESC_FULL, p);
+			object_desc(o_full_name, sizeof(o_full_name), obj,
+				ODESC_PREFIX | ODESC_FULL, p);
 			
 			/* Print the messages */
 			msg("You realize that your %s is %s.", o_short_name,
@@ -946,7 +953,8 @@ void ident_hunger(struct player *p)
 			ident(obj);
 
 			/* Full object description */
-			object_desc(o_full_name, sizeof(o_full_name), obj, ODESC_FULL, p);
+			object_desc(o_full_name, sizeof(o_full_name), obj,
+				ODESC_PREFIX | ODESC_FULL, p);
 
 			/* Print the messages */
             if (of_has(obj->flags, OF_HUNGER)) {
@@ -999,7 +1007,8 @@ void ident_weapon_by_use(struct object *obj, char *m_name, int flag, int brand,
 	ident(obj);
 	
 	/* Full object description */
-	object_desc(o_full_name, sizeof(o_full_name), obj, ODESC_FULL, p);
+	object_desc(o_full_name, sizeof(o_full_name), obj,
+		ODESC_PREFIX | ODESC_FULL, p);
 	
 	/* Description of the 'slay' */
 	slay_desc(slay_description, sizeof(slay_description), flag, brand, m_name);
@@ -1029,7 +1038,9 @@ void ident_bow_arrow_by_use(struct object *bow, struct object *arrows,
 		ident(arrows);
 
 		/* Full arrow description */
-		object_desc(a_full_name, sizeof(a_full_name), arrows, ODESC_FULL, p);
+		object_desc(a_full_name, sizeof(a_full_name), arrows,
+			ODESC_PREFIX | ODESC_FULL | ODESC_ALTNUM | (1 << 16),
+			p);
 
 		slay_desc(slay_description, sizeof(slay_description), arrow_flag,
 				  arrow_brand, m_name);
@@ -1046,7 +1057,8 @@ void ident_bow_arrow_by_use(struct object *bow, struct object *arrows,
 		ident(bow);
 
 		/* Full bow description */
-		object_desc(b_full_name, sizeof(b_full_name), bow, ODESC_FULL, p);
+		object_desc(b_full_name, sizeof(b_full_name), bow,
+			ODESC_PREFIX | ODESC_FULL, p);
 
 		slay_desc(slay_description, sizeof(slay_description), 0, bow_brand,
 				  m_name);

--- a/src/player-attack.c
+++ b/src/player-attack.c
@@ -780,8 +780,8 @@ static bool do_radiance(struct player *p, struct loc grid) {
 /**
  * Handle special effects of throwing certain potions
  */
-static bool thrown_potion_effects(struct object *obj, bool *is_dead,
-								  struct monster *mon)
+static bool thrown_potion_effects(struct player *p, struct object *obj,
+		bool *is_dead, struct monster *mon)
 {
 	struct loc grid = mon->grid;
 
@@ -822,27 +822,29 @@ static bool thrown_potion_effects(struct object *obj, bool *is_dead,
 		char o_name[80];
 
 		/* Identify it fully */
-		object_flavor_aware(player, obj);
+		object_flavor_aware(p, obj);
 		object_know(obj);
 
 		/* Description */
-		object_desc(o_name, sizeof(o_name), obj, ODESC_FULL, player);
+		object_desc(o_name, sizeof(o_name), obj,
+			ODESC_PREFIX | ODESC_FULL | ODESC_ALTNUM | (1 << 16),
+			p);
 
 		/* Describe the potion */
 		msg("You threw %s.", o_name);
 
 		/* Combine / Reorder the pack (later) */
-		player->upkeep->notice |= (PN_COMBINE);
+		p->upkeep->notice |= (PN_COMBINE);
 
 		/* Window stuff */
-		player->upkeep->redraw |= (PR_INVEN | PR_EQUIP);
+		p->upkeep->redraw |= (PR_INVEN | PR_EQUIP);
 	}
 
 	/* Redraw if necessary*/
-	if (used) player->upkeep->redraw |= (PR_HEALTH);
+	if (used) p->upkeep->redraw |= (PR_HEALTH);
 
 	/* Handle stuff */
-	handle_stuff(player);
+	handle_stuff(p);
 
 	return used;
 
@@ -1327,8 +1329,8 @@ static void ranged_helper(struct player *p,	struct object *obj, int dir,
 						msg("The bottle breaks.");
 					
 						/* Returns true if damage has already been handled */
-						potion_effect = thrown_potion_effects(obj, &fatal_blow,
-															  mon);
+						potion_effect = thrown_potion_effects(
+							p, obj, &fatal_blow, mon);
 
 						/* Check the change in monster hp*/
 						pdam -= mon->hp;
@@ -1430,7 +1432,9 @@ static void ranged_helper(struct player *p,	struct object *obj, int dir,
 			char o_short_name[80];
 			object_desc(o_short_name, sizeof(o_short_name), obj, ODESC_BASE, p);
 			object_know(bow);
-			object_desc(o_full_name, sizeof(o_full_name), obj, ODESC_FULL, p);
+			object_desc(o_full_name, sizeof(o_full_name), obj,
+				ODESC_PREFIX | ODESC_FULL | ODESC_ALTNUM |
+				(1 << 16), p);
 			msg("The arrow leaves behind a trail of light!");
 			msg("You recognize your %s to be %s", o_short_name, o_full_name);
 		}


### PR DESCRIPTION
Resolves https://github.com/NickMcConnell/NarSil/issues/316 .  Refactors thrown_potion_effects() to use the player argument passed to ranged_helper() rather than the player global.