### PR TITLE
Fix cursed skill checks

### DIFF
--- a/src/combat.c
+++ b/src/combat.c
@@ -157,11 +157,15 @@ int skill_check(struct source attacker, int skill, int difficulty,
 
 	/* Alternate rolls for dealing with the player curse */
 	if (player->cursed) { 
+		int alt_total;
+
 		if (attacker.what == SRC_PLAYER) {
-			skill_total = MIN(skill_total, randint1(10) + skill);
+			alt_total = randint1(10) + skill;
+			skill_total = MIN(skill_total, alt_total);
 		}
 		if (defender.what == SRC_PLAYER) {
-			difficulty_total = MIN(difficulty_total, randint1(10) + difficulty);
+			alt_total = randint1(10) + difficulty;
+			difficulty_total = MIN(difficulty_total, alt_total);
 		}
 	}
 


### PR DESCRIPTION
As a macro, MIN() can evaluate its arguments more than once leading to incorrect results if those arguments can change (for example, if an argument includes a call to a random number generator) between evaluations.