### PR TITLE
Fix refueling lanterns

### DIFF
--- a/src/cmd-obj.c
+++ b/src/cmd-obj.c
@@ -814,7 +814,7 @@ void do_cmd_use(struct command *cmd)
 
 static void refill_lamp(struct object *lamp, struct object *obj)
 {
-	int timeout = obj->timeout ? obj->timeout : obj->pval;
+	int timeout = lamp->timeout + (obj->timeout ? obj->timeout : obj->pval);
 
 	/* Message */
 	if (timeout > z_info->fuel_lamp) {
@@ -822,7 +822,7 @@ static void refill_lamp(struct object *lamp, struct object *obj)
 			if (!get_check("Refueling from this lantern will waste some fuel. Proceed? ")) {
 				return;
 			}
-		} else if (get_check("Refueling from this flask will waste some fuel. Proceed? ")) {
+		} else if (!get_check("Refueling from this flask will waste some fuel. Proceed? ")) {
 			return;
 		}
 	} else {

--- a/src/obj-util.c
+++ b/src/obj-util.c
@@ -634,6 +634,9 @@ bool obj_is_useable(const struct object *obj)
 	if (object_effect(obj))
 		return true;
 
+	if (obj_can_refuel(obj))
+		return true;
+
 	if (tval_is_ammo(obj))
 		return obj->tval == player->state.ammo_tval;
 


### PR DESCRIPTION
1) Increase the timeout rather than replace the timeout with that of the fuel source.
2) Reverse logic for skipping fueling from a flask if it would waste fuel.
3) Allow the use command for flasks if the character has a lantern equipped.

Resolves Bill Peterson's report here, http://angband.oook.cz/forum/showpost.php?p=161407&postcount=4 .