### PR TITLE
Mark cursed jewellery with OBJ_NOTICE_CURSED and OBJ_NOTICE_BROKEN

### DIFF
--- a/src/obj-make.c
+++ b/src/obj-make.c
@@ -858,10 +858,17 @@ void apply_magic(struct object *obj, int lev, bool allow_artifacts, bool good,
 			apply_magic_armour(obj, lev);
 		}
 	} else if (tval_is_jewelry(obj)) {
-		/* For jewellery, some negative values mean cursed */
-		if ((obj->att < 0) || (obj->evn < 0)) of_on(obj->flags, OF_CURSED);
+		/* For jewellery, some negative values mean cursed and broken */
+		if ((obj->att < 0) || (obj->evn < 0)) {
+			of_on(obj->flags, OF_CURSED);
+			obj->notice |= (OBJ_NOTICE_CURSED | OBJ_NOTICE_BROKEN);
+		}
 		for (i = 0; i < OBJ_MOD_MAX; i++) {
-			if (obj->modifiers[i] < 0) of_on(obj->flags, OF_CURSED);
+			if (obj->modifiers[i] < 0) {
+				of_on(obj->flags, OF_CURSED);
+				obj->notice |=
+					(OBJ_NOTICE_CURSED | OBJ_NOTICE_BROKEN);
+			}
 		}
 	} else if (tval_is_light(obj)) {
 		if (special) {


### PR DESCRIPTION
That's to match Sil 1.3 and resolve Infinitum's report, http://angband.oook.cz/forum/showpost.php?p=161417&postcount=6 , that a staff of sanctity did not work with a cursed amulet of constitution.