### PR TITLE
pick_and_place_monster_on_stairs(): only return true if seen

### DIFF
--- a/src/mon-make.c
+++ b/src/mon-make.c
@@ -1497,8 +1497,8 @@ bool pick_and_place_monster_on_stairs(struct chunk *c, struct player *p,
 				} else {
 					msg("%s!", message);
 			}
+			return true;
 		}
-		return true;
 	}
 
 	/* Didn't happen or not seen */


### PR DESCRIPTION
That's to better match Sil 1.3 and resolve Infinitum's report here, http://angband.oook.cz/forum/showthread.php?t=11559 , that staffs of summoning are identified by use even if the effect is not seen.