### PR TITLE
free_birth_menu(): set menu_data to NULL to avoid downstream double frees

### DIFF
--- a/src/ui-birth.c
+++ b/src/ui-birth.c
@@ -567,6 +567,7 @@ static void free_birth_menu(struct menu *menu)
 	if (data) {
 		mem_free(data->items);
 		mem_free(data);
+		menu->menu_data = NULL;
 	}
 }
 


### PR DESCRIPTION
Resolves https://github.com/NickMcConnell/NarSil/issues/337 .