### PR TITLE
Allow the use command to equip an unequipped wearable item

### DIFF
--- a/src/cmd-obj.c
+++ b/src/cmd-obj.c
@@ -801,6 +801,7 @@ void do_cmd_use(struct command *cmd)
 	else if (tval_is_horn(obj))			do_cmd_blow_horn(cmd);
 	else if (tval_is_staff(obj))		do_cmd_use_staff(cmd);
 	else if (obj_can_refuel(obj))		do_cmd_refuel(cmd);
+	else if (tval_is_wearable(obj))		do_cmd_wield(cmd);
 	else
 		msg("The item cannot be used at the moment");
 }

--- a/src/obj-util.c
+++ b/src/obj-util.c
@@ -634,6 +634,17 @@ bool obj_is_useable(const struct object *obj)
 	if (object_effect(obj))
 		return true;
 
+	/*
+	 * Could do further testing to see if the equipped object, if any, can
+	 * be removed, but for items (like rings) that can go in more than one
+	 * slot there are extra complications to the logic (using wield_slot()
+	 * and slot_object() is not sufficient if all the appropriate slots
+	 * are full and the slot from wield_slot() has a cursed item but
+	 * another appropriate slot has an uncursed item).
+	 */
+	if (tval_is_wearable(obj) && !object_is_equipped(player->body, obj))
+		return true;
+
 	if (obj_can_refuel(obj))
 		return true;
 


### PR DESCRIPTION
Like Sil 1.3, using a torch or lantern will prefer to tap it as a fuel source, if there is a similar light source equipped, rather than equipping it.  Resolves Infinitum's report here, http://angband.oook.cz/forum/showpost.php?p=161397&postcount=2 , of not being able to use an item to equip it.