### PR TITLE
In summon_specific() use requested level as is

### DIFF
--- a/src/mon-summon.c
+++ b/src/mon-summon.c
@@ -345,8 +345,7 @@ int summon_specific(struct loc grid, int lev, int type)
 	get_mon_num_prep(summon_specific_okay);
 
 	/* Pick a monster, using the level calculation */
-	race = get_mon_num((player->depth + lev) / 2 + 5, false, true,
-					   player->depth);
+	race = get_mon_num(lev, false, true, player->depth);
 
 	/* Prepare allocation table */
 	get_mon_num_prep(NULL);


### PR DESCRIPTION
That's to match Sil 1.3 rather than the Angband calculation which averages it with the player's depth and then boosts that result by 5.  Should resolve Infinitum's report here, http://angband.oook.cz/forum/showpost.php?p=161397&postcount=2 , of an overly deadly roost with a Shadow Spider.