### PR TITLE
Only show the "Throw" context menu option for objects that can be thrown

### DIFF
--- a/src/obj-util.c
+++ b/src/obj-util.c
@@ -582,6 +582,19 @@ bool obj_can_takeoff(const struct object *obj)
 		|| player_active_ability(player, "Curse Breaking");
 }
 
+/*
+ * Can only throw an item that is not equipped or the equipped weapon if it
+ * can be taken off.
+ *
+ * Note: that is Angband's behavior; Sil 1.3 allows other equippped items to
+ * be thrown if they can be taken off.
+ */
+bool obj_can_throw(const struct object *obj)
+{
+	return !object_is_equipped(player->body, obj)
+		|| (tval_is_melee_weapon(obj) && obj_can_takeoff(obj));
+}
+
 /* Can only put on wieldable items */
 bool obj_can_wear(const struct object *obj)
 {

--- a/src/obj-util.h
+++ b/src/obj-util.h
@@ -49,6 +49,7 @@ bool obj_can_dig(const struct object *obj);
 bool obj_has_charges(const struct object *obj);
 bool obj_can_refuel(const struct object *obj);
 bool obj_can_takeoff(const struct object *obj);
+bool obj_can_throw(const struct object *obj);
 bool obj_can_wear(const struct object *obj);
 bool obj_can_fire(const struct object *obj);
 bool obj_is_throwing(const struct object *obj);

--- a/src/player-attack.c
+++ b/src/player-attack.c
@@ -1490,16 +1490,6 @@ static void ranged_helper(struct player *p,	struct object *obj, int dir,
 
 
 /**
- * Help do_cmd_throw():  restrict which equipment can be thrown.
- */
-static bool restrict_for_throwing(const struct object *obj)
-{
-	return !object_is_equipped(player->body, obj) ||
-			(tval_is_melee_weapon(obj) && obj_can_takeoff(obj));
-}
-
-
-/**
  * Fire an object from the quiver, pack or floor at a target.
  */
 void do_cmd_fire(struct command *cmd) {
@@ -1575,7 +1565,7 @@ void do_cmd_throw(struct command *cmd) {
 	if (cmd_get_item(cmd, "item", &obj,
 			/* Prompt */ "Throw which item?",
 			/* Error  */ "You have nothing to throw.",
-			/* Filter */ restrict_for_throwing,
+			/* Filter */ obj_can_throw,
 			/* Choice */ USE_EQUIP | USE_QUIVER | USE_INVEN | USE_FLOOR | SHOW_THROWING)
 		!= CMD_OK)
 		return;

--- a/src/ui-context.c
+++ b/src/ui-context.c
@@ -691,7 +691,10 @@ int context_menu_object(struct object *obj)
 		ADD_LABEL("Pick up", CMD_PICKUP, valid);
 	}
 
-	ADD_LABEL("Throw", CMD_THROW, MN_ROW_VALID);
+	if (obj_can_throw(obj)) {
+		ADD_LABEL("Throw", CMD_THROW, MN_ROW_VALID);
+	}
+
 	ADD_LABEL("Inscribe", CMD_INSCRIBE, MN_ROW_VALID);
 
 	if (obj_has_inscrip(obj))


### PR DESCRIPTION
Ported from Angband.  Which items can be thrown remains as it was in NarSil 1.3 though that is different than Sil 1.3.