### PR TITLE
Fix duplicate delete_monster_idx() calls in death from monster's projection

### DIFF
--- a/src/project-mon.c
+++ b/src/project-mon.c
@@ -452,9 +452,6 @@ static bool project_m_monster_attack(project_monster_handler_context_t *context,
 		/* Generate treasure, etc */
 		monster_death(mon, player, false, NULL, false);
 
-		/* Delete the monster */
-		delete_monster_idx(cave, m_idx);
-
 		mon_died = true;
 	} else {
 		/* Alert it */


### PR DESCRIPTION
monster_death() already calls delete_monster_idx() so another call to it is fatal.  Resolves Infinitum's report here, http://angband.oook.cz/forum/showpost.php?p=161397&postcount=2 , of "Red serpent breathes fire, doesn't kill me, kills green serpent. Game crashes to desktop."