### PR TITLE
Prevent crashes when wielding into an empty off-hand weapon slot

### DIFF
--- a/src/cmd-obj.c
+++ b/src/cmd-obj.c
@@ -369,6 +369,10 @@ void do_cmd_wield(struct command *cmd)
 			if (get_check("Do you wish to wield it in your off-hand? ")) {
 				slot = shield_slot;
 				equip_obj = slot_object(player, slot);
+				if (!equip_obj) {
+					inven_wield(obj, slot);
+					return;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Resolves Infinitum's report here, http://angband.oook.cz/forum/showpost.php?p=161397&postcount=2 : "Attempting to wield a dagger of accompaniment in the offhand (without native TWF) causes CTD."