### PR TITLE
Fix Opportunist attacks when monster flees via a staircase

### DIFF
--- a/src/mon-move.c
+++ b/src/mon-move.c
@@ -3466,9 +3466,9 @@ static void monster_turn(struct monster *mon)
 		if (rf_has(mon->race->flags, RF_SMART) &&
 			!rf_has(mon->race->flags, RF_TERRITORIAL) &&
 			(mon->stance == STANCE_FLEEING) &&
-			square_isstairs(cave, mon->grid)) {
+			square_isstairs(cave, tgrid)) {
 			if (monster_is_visible(mon)) {
-				if (square_isdownstairs(cave, mon->grid)) {
+				if (square_isdownstairs(cave, tgrid)) {
 					add_monster_message(mon, MON_MSG_FLEE_DOWN_STAIRS, true);
 				} else {
 					add_monster_message(mon, MON_MSG_FLEE_UP_STAIRS, true);
@@ -3486,8 +3486,8 @@ static void monster_turn(struct monster *mon)
 				!player->timed[TMD_AFRAID] &&
 				!player->timed[TMD_ENTRANCED] &&
 				(player->timed[TMD_STUN] <= 100) &&
-				(distance(mon->grid, player->grid) == 1)) {
-				py_attack_real(player, grid, ATT_OPPORTUNIST);
+				(distance(tgrid, player->grid) == 1)) {
+				py_attack_real(player, tgrid, ATT_OPPORTUNIST);
 			}
 
 			/* Removes the monster if it is still alive */


### PR DESCRIPTION
Does not resolve Infinitum's report here, http://angband.oook.cz/forum/showpost.php?p=161397&postcount=2 , of "Got it a few more times. Possibly related to opportunist; managed to pass the level by shutting that off. Not sure why only green s killed by opportunist attacks would crash the game though." since green serpents will not flee via a staircase.