### PR TITLE
Have whispering shadows show up in the wight/wraight category

### DIFF
--- a/src/ui-knowledge.c
+++ b/src/ui-knowledge.c
@@ -1100,7 +1100,7 @@ static struct
 	{ L"T",        "Trolls" },
 	{ L"v",        "Vampires" },
 	{ L"V",        "Valar" },
-	{ L"W",        "Wights/Wraiths" },
+	{ L"wW",       "Wights/Wraiths" },
 	{ L"@",        "Men/Elves" },
 	{ L"&",        "Thorns" },
 	{ L"|",        "Deathblades" },


### PR DESCRIPTION
Resolves part of Infinitum's report here, http://angband.oook.cz/forum/showpost.php?p=161397&postcount=2 : "Whispering Shadows don't show up in the monster memory since there's no worm category. Could go under W'ights etc, lore is they're remnants of defeated Maiar from ages past. Also their lore blurb looks like a draft; "(...) sounds (voices?)(...)" could be replaced by just "voices" and flow better imo."