### PR TITLE
Fix handling of undisarmable kinds of traps

### DIFF
--- a/src/cmd-cave.c
+++ b/src/cmd-cave.c
@@ -1090,9 +1090,9 @@ static bool do_cmd_disarm_aux(struct loc grid)
 		return !more;
 	}
 
-	/* Determine trap power */
+	/* Determine trap power; (uint8_t)-1 is undisarmable */
 	power = trap->power;
-	if (power < 0) {
+	if (power == (uint8_t)-1) {
 		msg("You cannot disarm the %s.", trap->kind->name);
 		return false;
 	}

--- a/src/trap.c
+++ b/src/trap.c
@@ -107,10 +107,19 @@ static enum parser_error parse_trap_max_depth(struct parser *p) {
 
 static enum parser_error parse_trap_power(struct parser *p) {
     struct trap_kind *t = parser_priv(p);
+    int power = parser_getint(p, "power");
 
     if (!t)
 		return PARSE_ERROR_MISSING_RECORD_HEADER;
-    t->power =  parser_getint(p, "power");
+    /*
+     * Internally, a trap instance uses a uint8_t to store the power so reject
+     * any power here that can not be unambiguously stored in a uint8_t.  -1
+     * means the trap is undisarmable.
+     */
+    if (power < -1 || power > 254) {
+        return PARSE_ERROR_INVALID_VALUE;
+    }
+    t->power = power;
     return PARSE_ERROR_NONE;
 }
 

--- a/src/tutorial.c
+++ b/src/tutorial.c
@@ -320,7 +320,7 @@ static void tutorial_section_place_custom_trap(struct chunk *c, struct loc grid,
 		struct trap *the_trap = square_trap(c, grid);
 
 		if (the_trap) {
-			the_trap->power = 255;
+			the_trap->power = 254;
 		}
 	}
 }


### PR DESCRIPTION
Resolves Infinitum's report here, http://angband.oook.cz/forum/showpost.php?p=161397&postcount=2 : "Not getting a warning that pits cannot be disarmed when trying to ctrl-move into a pit."