### PR TITLE
Remove tutorial's option for invisible traps

### DIFF
--- a/lib/gamedata/tutorial.txt
+++ b/lib/gamedata/tutorial.txt
@@ -571,10 +571,6 @@
 # VISIBLE
 #     The trap will start out visible and does not need to be detected by the
 #     player.
-# INVISIBLE
-#     Makes the trap so it won't be detected by merely observing the trap's
-#     location.  Does not affect the action of trap detection spells or
-#     devices.
 
 # door:symbol:flags
 # (Optional) Causes a door to be placed at a location the description marks

--- a/src/tutorial-init.c
+++ b/src/tutorial-init.c
@@ -2501,11 +2501,11 @@ static enum parser_error parse_section_monster(struct parser *p)
 
 static enum parser_error parse_section_trap(struct parser *p)
 {
-	const char *trap_flags[] = { "NONE", "VISIBLE", "INVISIBLE", NULL };
+	const char *trap_flags[] = { "NONE", "VISIBLE", NULL };
 	struct tutorial_parser_priv *priv = (struct tutorial_parser_priv*)
 		parser_priv(p);
 	struct trap_kind *trap;
-	bool vis, invis;
+	bool vis;
 	char *flags, *s;
 	struct tutorial_section_sym_key *key;
 	enum parser_error result;
@@ -2515,7 +2515,6 @@ static enum parser_error parse_section_trap(struct parser *p)
 	}
 	trap = lookup_trap(parser_getsym(p, "name"));
 	vis = false;
-	invis = false;
 	flags = string_make(parser_getstr(p, "flags"));
 	s = strtok(flags, " |");
 	while (s) {
@@ -2523,8 +2522,6 @@ static enum parser_error parse_section_trap(struct parser *p)
 
 		if (idx == 1) {
 			vis = true;
-		} else if (idx == 2) {
-			invis = true;
 		} else if (idx < 0) {
 			string_free(flags);
 			return PARSE_ERROR_INVALID_FLAG;
@@ -2541,7 +2538,6 @@ static enum parser_error parse_section_trap(struct parser *p)
 
 		value->v.trap.kind = trap;
 		value->v.trap.vis = vis;
-		value->v.trap.invis = invis;
 		value->is_predefined = false;
 		value->kind = SECTION_SYM_TRAP;
 		if (!tutorial_section_sym_table_insert(

--- a/src/tutorial-init.h
+++ b/src/tutorial-init.h
@@ -86,7 +86,7 @@ struct tutorial_section_sym_val {
 			int sleepiness;
 			bool sleepiness_fixed;
 		} monster;
-		struct { struct trap_kind *kind; bool vis, invis; } trap;
+		struct { struct trap_kind *kind; bool vis; } trap;
 		struct { int feat, power; } door;
 		struct { int feat, uses; } forge;
 		struct { char *dest; char *note; int feat; } gate;

--- a/src/tutorial.c
+++ b/src/tutorial.c
@@ -316,12 +316,6 @@ static void tutorial_section_place_custom_trap(struct chunk *c, struct loc grid,
 	place_trap(c, grid, val->v.trap.kind->tidx, c->depth);
 	if (val->v.trap.vis) {
 		square_reveal_trap(c, grid, false);
-	} else if (val->v.trap.invis) {
-		struct trap *the_trap = square_trap(c, grid);
-
-		if (the_trap) {
-			the_trap->power = 254;
-		}
 	}
 }
 


### PR DESCRIPTION
They are not used in the current tutorial's content and are missing logic in the main game's search code (and likely disarming code) to have them not be detected by searching and still be disarmable.