### PR TITLE
When appending spells to monster lore, set ref_race for expressions

### DIFF
--- a/src/mon-lore.c
+++ b/src/mon-lore.c
@@ -1130,8 +1130,13 @@ void lore_append_spells(textblock *tb, const struct monster_race *race,
 	monster_sex_t msex = MON_SEX_NEUTER;
 	const char *initial_pronoun;
 	bitflag current_flags[RSF_SIZE];
+	const struct monster_race *old_ref;
 
 	assert(tb && race && lore);
+
+	/* Set the race for expressions in the spells. */
+	old_ref = ref_race;
+	ref_race = race;
 
 	/* Extract a gender (if applicable) and get a pronoun for the start of
 	 * sentences */
@@ -1164,6 +1169,9 @@ void lore_append_spells(textblock *tb, const struct monster_race *race,
 		lore_append_spell_clause(tb, current_flags, race, COLOUR_ORANGE,
 								 COLOUR_WHITE);
 	}
+
+	/* Restore the previous reference. */
+	ref_race = old_ref;
 }
 
 /**


### PR DESCRIPTION
Possibly resolves https://github.com/NickMcConnell/NarSil/issues/350 .  Did see a crash when a green serpent was killed by a blow from the Opportunist skill:  in the lore update after the death, evaluating the expression for spell power tried to use cave_monster(cave, cave->mon_current)->race but that was NULL because the monster was dead.