### PR TITLE
Healing potions: heal 1/2 of max HP as in Sil 1.3

### DIFF
--- a/lib/gamedata/object.txt
+++ b/lib/gamedata/object.txt
@@ -1860,7 +1860,8 @@ effect:TIMED_SET:CUT
 dice:$B
 expr:B:PLAYER_CUT: / 2
 effect:HEAL_HP
-dice:m50
+dice:$B
+expr:B:PLAYER_MAX_HP: / 2
 effect:NOURISH:INC_BY
 dice:100
 flags:GOOD

--- a/src/effects.c
+++ b/src/effects.c
@@ -267,6 +267,11 @@ static int effect_value_base_player_hp(void)
 	return player->chp;
 }
 
+static int effect_value_base_player_max_hp(void)
+{
+	return player->mhp;
+}
+
 static int effect_value_base_player_will(void)
 {
 	int will = player->state.skill_use[SKILL_WILL];
@@ -297,6 +302,7 @@ expression_base_value_f effect_value_base_by_name(const char *name)
 		{ "DUNGEON_LEVEL", effect_value_base_dungeon_level },
 		{ "MAX_SIGHT", effect_value_base_max_sight },
 		{ "PLAYER_HP", effect_value_base_player_hp },
+		{ "PLAYER_MAX_HP", effect_value_base_player_max_hp },
 		{ "PLAYER_WILL", effect_value_base_player_will },
 		{ "PLAYER_CUT", effect_value_base_player_cut },
 		{ "PLAYER_POIS", effect_value_base_player_pois },


### PR DESCRIPTION
Were healing (max hp - curr hp) / 2.  Resolves Infinitum's report here, http://angband.oook.cz/forum/showpost.php?p=161471&postcount=23 : "Unconfirmed, but Healing potions seem to heal less than I remember from Sil."