### PR TITLE
Set centre for cases where it was not set before calling update_flow()

### DIFF
--- a/src/mon-group.c
+++ b/src/mon-group.c
@@ -326,6 +326,7 @@ void monster_group_new_wandering_flow(struct chunk *c, struct monster *mon,
 		/* They only pick a new location on creation.  Detect this using the
 		 * fact that speed hasn't been determined yet on creation */
 		if (mon->mspeed == 0) {
+			group->flow.centre = leader->grid;
 			update_flow(c, &group->flow, leader);
 		}
 	} else if (square_in_bounds_fully(c, tgrid)) {

--- a/src/mon-msg.c
+++ b/src/mon-msg.c
@@ -172,7 +172,8 @@ void message_warning(struct monster *mon)
 	add_monster_message(mon, msg_code, false);
 
 	/* Hard not to notice */
-	update_flow(cave, &cave->monster_noise, mon);
+	cave->monster_noise.centre = mon->grid;
+	update_flow(cave, &cave->monster_noise, NULL);
 	monsters_hear(false, false, -10);
 
 	/* Makes monster noise too */

--- a/src/player-quest.c
+++ b/src/player-quest.c
@@ -170,6 +170,7 @@ void break_truce(struct player *p, bool obvious)
 				msg("%s lets out a cry! The tension is broken.", m_name);
 
 				/* Make a lot of noise */
+				cave->monster_noise.centre = mon->grid;
 				update_flow(cave, &cave->monster_noise, NULL);
 				monsters_hear(false, false, -10);
 			} else {


### PR DESCRIPTION
Resolves https://github.com/NickMcConnell/NarSil/issues/375 .  May impact https://github.com/NickMcConnell/NarSil/issues/351 .  Where the centre was not set for monster's warning messages, also use NULL for the mon argument to update_flow() since the flow update is for noise rather than pathfinding.