### PR TITLE
Monster's crippling shot: always give message and slowing

### DIFF
--- a/src/project-player.c
+++ b/src/project-player.c
@@ -288,11 +288,11 @@ static void monster_ranged_attack(project_player_handler_context_t *context,
 					/* Remember that the monster can do this */
 					if (monster_is_visible(mon)) {
 						rf_on(lore->flags, RF_CRIPPLING);
-						msg("The shot tears into your thigh!");
-						/* Slow the player */
-						player_inc_timed(player, TMD_SLOW, crit_bonus_dice,
-										 true, false);
 					}
+					msg("The shot tears into your thigh!");
+					/* Slow the player */
+					player_inc_timed(player, TMD_SLOW, crit_bonus_dice,
+						true, false);
 				}
 			}
 		}


### PR DESCRIPTION
That matches Sil 1.3.  Resolves https://github.com/NickMcConnell/NarSil/issues/373 .