### PR TITLE
Record ego's aware flag when saving; restore it when loading

### DIFF
--- a/src/load.c
+++ b/src/load.c
@@ -894,9 +894,10 @@ int rd_ignore(void)
 		if (i < z_info->e_max) {
 			bitflag flags, itypes[ITYPE_SIZE];
 			
-			/* Read and extract the everseen flag */
+			/* Read and extract the everseen and aware flags */
 			rd_byte(&flags);
 			e_info[i].everseen = (flags & 0x02) ? true : false;
+			e_info[i].aware = (flags & 0x04) ? true : false;
 
 			/* Read and extract the ignore flags */
 			for (j = 0; j < itype_size; j++)

--- a/src/save.c
+++ b/src/save.c
@@ -566,9 +566,11 @@ void wr_ignore(void)
 	for (i = 0; i < z_info->e_max; i++) {
 		bitflag everseen = 0, itypes[ITYPE_SIZE];
 
-		/* Figure out and write the everseen flag */
+		/* Figure out and write the everseen and aware flags */
 		if (e_info[i].everseen)
 			everseen |= 0x02;
+		if (e_info[i].aware)
+			everseen |= 0x04;
 		wr_byte(everseen);
 
 		/* Figure out and write the ignore flags */


### PR DESCRIPTION
Resolves Infinitum's reports here http://angband.oook.cz/forum/showpost.php?p=161484&postcount=30 : "Upon closing the program and restoring a saved game, player seems to have forgotten a lot of known items? Especially weapon egos. Needs confirmation." and "Confirming that a lot of weapons egos drops out of knowledge after restoring the game. Re-Id'ing Nargothrond and whatnot. Get new xp for rediscovering. Not sure about other item types."