### PR TITLE
For instant artifact kinds, inherit flags and element info of the tval

### DIFF
--- a/lib/gamedata/object.txt
+++ b/lib/gamedata/object.txt
@@ -226,7 +226,7 @@ flags:INSTA_ART
 # The Mighty Hammer 'Grond'
 
 # Index 19
-name:& Mighty Hammer~
+#name:& Mighty Hammer~
 #graphics:\:D
 #type:hafted
 #depth:20

--- a/src/obj-init.c
+++ b/src/obj-init.c
@@ -157,6 +157,12 @@ static enum parser_error write_dummy_object_record(struct artifact *art, const c
 	dummy->d_char = '*';
 	dummy->d_attr = COLOUR_RED;
 
+	/* Inherit the flags and element information of the tval */
+	of_copy(dummy->flags, kb_info[i].flags);
+	kf_copy(dummy->kind_flags, kb_info[i].kind_flags);
+	(void)memcpy(dummy->el_info, kb_info[i].el_info,
+		sizeof(dummy->el_info[0]) * ELEM_MAX);
+
 	/* Register this as an INSTA_ART object */
 	kf_on(dummy->kind_flags, KF_INSTA_ART);
 


### PR DESCRIPTION
Resolves Infinitum's report here http://angband.oook.cz/forum/showpost.php?p=161484&postcount=30 :  "Grond lacks damage dice."