### PR TITLE
Refactor player_has_ability() to test full ability rather than name

### DIFF
--- a/src/obj-gear.c
+++ b/src/obj-gear.c
@@ -940,7 +940,7 @@ void inven_wield(struct object *obj, int slot)
 
 	/* Activate all of its new abilities */
 	for (ability = wielded->abilities; ability; ability = ability->next) {
-		if (!player_has_ability(player, ability->name)) {
+		if (!player_has_ability(player, ability)) {
 			add_ability(&player->item_abilities, ability);
 			activate_ability(&player->item_abilities, ability);
 		}

--- a/src/player-abilities.c
+++ b/src/player-abilities.c
@@ -420,16 +420,11 @@ void remove_ability(struct ability **ability, struct ability *remove)
 	}
 }
 
-static bool player_innate_ability(struct player *p, const char *name)
+bool player_has_ability(struct player *p, struct ability *ability)
 {
-	struct ability *ability = p->abilities;
-	return ability ? !!test_ability(name, ability, NULL) : false;
-}
-
-bool player_has_ability(struct player *p, const char *name)
-{
-	if (player_innate_ability(p, name)) return true;
-	if (test_ability(name, p->item_abilities, NULL)) return true;
+	if (!ability) return false;
+	if (locate_ability(p->abilities, ability)) return true;
+	if (locate_ability(p->item_abilities, ability)) return true;
 	return false;
 }
 

--- a/src/player-abilities.h
+++ b/src/player-abilities.h
@@ -50,7 +50,7 @@ struct ability *locate_ability(struct ability *ability, struct ability *test);
 void add_ability(struct ability **set, struct ability *add);
 void activate_ability(struct ability **set, struct ability *activate);
 void remove_ability(struct ability **ability, struct ability *remove);
-bool player_has_ability(struct player *p, const char *name);
+bool player_has_ability(struct player *p, struct ability *ability);
 int player_active_ability(struct player *p, const char *name);
 bool player_has_prereq_abilities(struct player *p, struct ability *ability);
 int player_ability_cost(struct player *p, struct ability *ability);

--- a/src/tutorial.c
+++ b/src/tutorial.c
@@ -615,6 +615,7 @@ static void tutorial_handle_player_move(game_event_type t, game_event_data *d,
 		for (iop = 0; iop < entry->v.trigger.expr.n_op; ++iop) {
 			const struct trigger_compiled_op *op =
 					entry->v.trigger.expr.ops + iop;
+			struct ability *ability;
 
 			switch (op->kind) {
 			case TRIGGER_OP_NOT:
@@ -650,8 +651,9 @@ static void tutorial_handle_player_move(game_event_type t, game_event_data *d,
 
 			case TRIGGER_OP_ABILITY:
 				assert(next < entry->v.trigger.expr.n_stack);
+				ability = lookup_ability(op->idx, op->name);
 				estack[next] =
-					player_has_ability(player, op->name);
+					player_has_ability(player, ability);
 				++next;
 				break;
 

--- a/src/ui-abilities.c
+++ b/src/ui-abilities.c
@@ -162,7 +162,7 @@ static void ability_browser(int oid, void *data, const region *loc)
 {
 	struct ability **choice = data;
 	struct ability *current = choice[oid];
-	bool learned = player_has_ability(player, current->name);
+	bool learned = player_has_ability(player, current);
 	uint8_t attr = COLOUR_L_DARK;
 	bool points = player->skill_base[current->skill] >= current->level;
 
@@ -196,7 +196,7 @@ static void ability_browser(int oid, void *data, const region *loc)
 		}
 		Term_gotoxy(text_out_indent + 2, 13);
 		while (prereq) {
-			if (player_has_ability(player, prereq->name)) {
+			if (locate_ability(player->abilities, prereq)) {
 				attr = COLOUR_SLATE;
 			} else {
 				attr = COLOUR_L_DARK;


### PR DESCRIPTION
Resolves Infinitum's report here, http://angband.oook.cz/forum/showpost.php?p=161484&postcount=30 , that taking Dexterity from the Evasion tree meant that the user interface stopped displaying the prequisites for Dexterity from the Stealth tree, as if it had already been taken.  Also, for coloring the prerequisity abilities, only use slate for the ones that are innate to match Sil 1.3 (see cmd4.c:1172).