### PR TITLE
Don't call object_desc() for a Silmaril:  result is unused

### DIFF
--- a/src/player-quest.c
+++ b/src/player-quest.c
@@ -248,7 +248,6 @@ void prise_silmaril(struct player *p)
 	int noise = 0;
 	int mds = p->state.mds;
 	int attack_mod = p->state.skill_use[SKILL_MELEE];
-	char o_name[80];
 	struct monster_race *race = lookup_monster("Morgoth, Lord of Darkness");
 
 	/* The Crown is on the ground */
@@ -359,9 +358,6 @@ void prise_silmaril(struct player *p)
 
 			/* Get it */
 			inven_carry(p, sil, true, true);
-
-			/* Describe the object */
-			object_desc(o_name, sizeof(o_name), sil, true, p);
 
 			/* Break the truce (always) */
 			break_truce(p, true);


### PR DESCRIPTION
The call also triggers a use after free if the second Silmaril was pried out while the first was in the inventory (the second combines with the first causing memory referenced by sil in prise_silmaril() to be freed).  May resolve Infinitum's report here, http://angband.oook.cz/forum/showpost.php?p=161484&postcount=30 , of a crash after prying out the second Silmaril.