### PR TITLE
More closely match Sil 1.3's bane selection menu

### DIFF
--- a/src/player-util.c
+++ b/src/player-util.c
@@ -900,16 +900,20 @@ static const int bane_flag[] = {
 	#undef BANE
 };
 
-static int player_bane_type_killed(int i)
+int player_bane_type_killed(int bane_type)
 {
-	int j, k = 0;
+	int j, k;
+
+	if (bane_type < 0 || bane_type >= (int)N_ELEMENTS(bane_flag)) {
+		return 0;
+	}
 
 	/* Scan the monster races */
-	for (j = 1; j < z_info->r_max; j++) {
+	for (j = 1, k = 0; j < z_info->r_max; j++) {
 		struct monster_race *race = &r_info[j];
 		struct monster_lore *lore = get_lore(race);
 
-		if (rf_has(race->flags, bane_flag[i])) {
+		if (rf_has(race->flags, bane_flag[bane_type])) {
 			k += lore->pkills;
 		}
 	}

--- a/src/player-util.h
+++ b/src/player-util.h
@@ -99,6 +99,7 @@ bool player_action_is_movement(struct player *p, int n);
 int player_dodging_bonus(struct player *p);
 bool player_can_riposte(struct player *p, int hit_result);
 bool player_is_sprinting(struct player *p);
+int player_bane_type_killed(int bane_type);
 int calc_bane_bonus(struct player *p);
 int player_bane_bonus(struct player *p, struct monster *mon);
 int player_spider_bane_bonus(struct player *p);


### PR DESCRIPTION
Resolves Infinitum's report here, http://angband.oook.cz/forum/showpost.php?p=161397&postcount=2 : "Some buggy menuing trying to gain the bane ability. Texts not formatted properly, cannot choose a category and the game allows the player to choose bane without specifying a category whilst trying to esc out."