### PR TITLE
Unique friend placement: place friend rather than self

### DIFF
--- a/src/mon-make.c
+++ b/src/mon-make.c
@@ -1004,7 +1004,7 @@ static void place_monster_unique_friend(struct chunk *c, struct loc grid,
 			/* Check each direction */
 			for (i = start; i < 8 + start; i++) {
 				struct loc try = loc_sum(grid, ddgrid_ddd[i % 8]);
-				if (place_new_monster_one(c, try, race, sleep, true, group_info,
+				if (place_new_monster_one(c, try, race1, sleep, true, group_info,
 										  origin)) {
 					/* Success */
 					break;


### PR DESCRIPTION
Resolves Infinitum's report here, http://angband.oook.cz/forum/showpost.php?p=161484&postcount=30 , of Tevildo appearing without Oikeroi.