### PR TITLE
Add punctuation for falling into a pit message.

### DIFF
--- a/lib/gamedata/trap.txt
+++ b/lib/gamedata/trap.txt
@@ -113,7 +113,7 @@ desc:A hole dug to snare the unwary.
 
 # spiked pit
 
-name:pit:spiked pit
+name:spiked pit:spiked pit
 graphics:^:s
 rarity:1
 min-depth:11
@@ -211,7 +211,7 @@ msg-xtra:It pierces your foot.
 
 # rune -- summon (OoD) monster
 
-name:monster nest:roost
+name:roost:roost
 graphics:^:B
 rarity:1
 min-depth:3
@@ -225,7 +225,7 @@ msg-xtra:There is a flutter of wings from high above.
 
 # rune -- summon monsters
 
-name:monster nest:web
+name:web:web
 graphics:^:B
 rarity:1
 min-depth:8
@@ -255,7 +255,7 @@ msg:The ceiling collapses!
 
 # spot -- acid
 
-name:discolored spot:acid trap
+name:discoloured spot:acid trap
 graphics:^:u
 rarity:1
 min-depth:1

--- a/src/player-util.c
+++ b/src/player-util.c
@@ -428,7 +428,7 @@ void player_fall_in_pit(struct player *p, bool spiked)
 	char name[50];
 	square_apparent_name(cave, p->grid, name, sizeof(name));
 
-	msg("You fall into a %s", name);
+	msg("You fall into a %s!", name);
 
 	/* Update combat rolls */
 	event_signal_combat_attack(EVENT_COMBAT_ATTACK, source_grid(p->grid),


### PR DESCRIPTION
Also, better match trap names to the short and long descriptions.  Resolves https://github.com/NickMcConnell/NarSil/issues/392 .