### PR TITLE
On a player's ranged attack, only use monster pain message if out of sight

### DIFF
--- a/src/player-attack.c
+++ b/src/player-attack.c
@@ -1395,7 +1395,7 @@ static void ranged_helper(struct player *p,	struct object *obj, int dir,
 						}
 
 						/* Message if applicable */
-						if (!potion_effect || (pdam > 0)) {
+						if ((!potion_effect || (pdam > 0)) && !monster_is_visible(mon)) {
 							message_pain(mon, pdam ? pdam : result.dmg);
 						}
 


### PR DESCRIPTION
Matches Sil 1.3 behavior (there visibility check is built into message_pain()) and resolves https://github.com/NickMcConnell/NarSil/issues/398 .