### PR TITLE
Do not display a pass door message for monster going through an open door

### DIFF
--- a/src/mon-move.c
+++ b/src/mon-move.c
@@ -2923,10 +2923,8 @@ static void process_move(struct monster *mon, struct loc tgrid, bool bash)
 		/* Monster is visible and not cloaked */
 		if (monster_is_visible(mon)) {
 			/* Report passing through doors */
-			if (square_isdoor(cave, mon->grid)) {
-				if (rf_has(race->flags, RF_PASS_DOOR)) {
-					add_monster_message(mon, MON_MSG_PASS_DOOR, true);
-				}
+			if (did_pass_door) {
+				add_monster_message(mon, MON_MSG_PASS_DOOR, true);
 			}
 
 			/* Player will always be disturbed */


### PR DESCRIPTION
Resolves https://github.com/NickMcConnell/NarSil/issues/399 and matches Sil 1.3's behavior.