### PR TITLE
Have artifact count match up after reloading with smithed artifacts

### DIFF
--- a/src/load.c
+++ b/src/load.c
@@ -1001,10 +1001,22 @@ int rd_artifacts(void)
 			note(format("Too many (%u) artifacts!", tmp16u));
 			return (-1);
 		}
+		tmp16u = z_info->a_max;
+	} else if(tmp16u < z_info->a_max) {
+		/*
+		 * Tolerate getting fewer artifacts than expected, but if
+		 * the additional artifacts are not at the end of the list,
+		 * the loaded data for aup_info will not match up with the
+		 * expanded set of artifacts.
+		 */
+		if (!player->is_dead) {
+			note(format("Expected %u artifacts; got %u.",
+				z_info->a_max, tmp16u));
+		}
 	}
 
 	/* Read the artifact flags */
-	for (i = 0; i < z_info->a_max; i++) {
+	for (i = 0; i < tmp16u; i++) {
 		uint8_t tmp8u;
 
 		rd_byte(&tmp8u);

--- a/src/obj-smith.c
+++ b/src/obj-smith.c
@@ -1110,7 +1110,8 @@ void add_artefact_details(struct artifact *art, struct object *obj)
 	int i;
 	struct smithing_cost dummy;
 
-	art->aidx = z_info->a_max;
+	/* Skip using an artifact index of zero. */
+	art->aidx = (z_info->a_max) ? z_info->a_max : 1;
 	art->tval = obj->tval;
 	art->sval = obj->sval;
 	art->pval = obj->pval;
@@ -1352,12 +1353,15 @@ static void create_smithing_item(struct object *obj, struct smithing_cost *cost)
 	/* If making an artefact, copy its attributes into the proper place in
 	 * the a_info array (noting aidx has already been set) */
 	if (obj->artifact) {
-		uint16_t aidx = z_info->a_max;
+		uint16_t aidx = (z_info->a_max) ? z_info->a_max : 1;
 		assert(aidx == obj->artifact->aidx);
-		z_info->a_max++;
+		z_info->a_max = aidx + 1;
 		a_info = mem_realloc(a_info, z_info->a_max * sizeof(struct artifact));
 		aup_info = mem_realloc(aup_info, z_info->a_max * sizeof(*aup_info));
-
+		if (aidx == 1) {
+			memset(&a_info[0], 0, sizeof(a_info[0]));
+			memset(&aup_info[0], 0, sizeof(aup_info[0]));
+		}
 		memset(&a_info[aidx], 0, sizeof(a_info[aidx]));
 		artefact_copy(&a_info[aidx], (struct artifact *) obj->artifact);
 		a_info[aidx].name = string_make(a_info[aidx].name);


### PR DESCRIPTION
Resolves https://github.com/NickMcConnell/NarSil/issues/415 .

Tolerate but warn if the number of artifacts in the save file is less than expected when reloaded.  As a bit of tolerance for modding, tolerate z_info->a_max being zero when a smithed artifact is created but skip using an artifact index of zero to agree with how artifact indices are used.