### PR TITLE
Workflows: update versions of used actions for compatibility with Node 20

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -16,7 +16,7 @@ jobs:
           sudo apt-get install gcc automake autoconf make libx11-dev
 
       - name: Clone Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build
         run: |
@@ -36,7 +36,7 @@ jobs:
           sudo apt-get install gcc make cmake libx11-dev
 
       - name: Clone Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build
         run: |
@@ -55,7 +55,7 @@ jobs:
           sudo apt-get install gcc make cmake libncursesw5-dev
 
       - name: Clone Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build
         run: |
@@ -74,7 +74,7 @@ jobs:
           sudo apt-get install gcc make cmake libsdl-image1.2-dev libsdl-ttf2.0-dev libsdl-mixer1.2-dev
 
       - name: Clone Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build
         run: |
@@ -93,7 +93,7 @@ jobs:
           sudo apt-get install gcc autoconf automake make libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev libsdl2-mixer-dev
 
       - name: Clone Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build
         run: |
@@ -111,7 +111,7 @@ jobs:
           sudo apt-get install gcc autoconf automake make libsqlite3-dev libsdl1.2-dev libsdl-mixer1.2-dev
 
       - name: Clone Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Turn on sound and the test front end so more of the basic
       # infrastructure is compiled.
@@ -131,7 +131,7 @@ jobs:
           sudo apt-get install gcc make libncursesw5-dev libx11-dev libsdl-image1.2-dev libsdl-ttf2.0-dev libsdl-mixer1.2-dev libsqlite3-dev
 
       - name: Clone Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build
         run: |

--- a/.github/workflows/mac.yaml
+++ b/.github/workflows/mac.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Clone Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,7 +49,7 @@ jobs:
       # Need commit history and tags for scripts/version.sh to work as expected
       # so use 0 for fetch-depth.
       - name: Clone Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -86,7 +86,7 @@ jobs:
           echo draft= '${{ steps.get_release_vars.outputs.draft }}' >> $CONFIG_ARTIFACT_PATH
 
       - name: Upload Artifact for Use by Dependent Steps
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.CONFIG_ARTIFACT }}
           path: ${{ env.CONFIG_ARTIFACT_PATH }}
@@ -116,7 +116,7 @@ jobs:
       # Need commit history and tags for scripts/version.sh to work as expected
       # so use 0 for fetch-depth.
       - name: Clone Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -131,7 +131,7 @@ jobs:
           tar -cf ${{ env.DOC_ARTIFACT_PATH }} docs/_build/html
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.DOC_ARTIFACT }}
           path: ${{ env.DOC_ARTIFACT_PATH }}
@@ -143,7 +143,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download Artifact with Configuration Information
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.CONFIG_ARTIFACT }}
 
@@ -165,7 +165,7 @@ jobs:
       # Need commit history and tags for scripts/version.sh to work as expected
       # so use 0 for fetch-depth.
       - name: Clone Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -183,14 +183,14 @@ jobs:
           echo archive_path= '${{ steps.create_source_archive.outputs.archive_file }}' > $SRC_ARTIFACT_PATH
 
       - name: Upload Artifact with Source Archive Path
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.SRC_ARTIFACT }}
           path: ${{ env.SRC_ARTIFACT_PATH }}
           retention-days: 1
 
       - name: Upload Source Archive as Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.SRC_ARCHIVE_ARTIFACT }}
           path: ${{ steps.create_source_archive.outputs.archive_file }}
@@ -202,7 +202,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Download Artifact with Configuration Information
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.CONFIG_ARTIFACT }}
 
@@ -224,12 +224,12 @@ jobs:
       # Need commit history and tags for scripts/version.sh to work as expected
       # so use 0 for fetch-depth.
       - name: Clone Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Download Artifact with Converted Documents
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.DOC_ARTIFACT }}
 
@@ -258,14 +258,14 @@ jobs:
           echo archive_path= '${{ steps.create_windows_archive.outputs.archive_file }}' > $WIN_ARTIFACT_PATH
 
       - name: Upload Artifact with Windows Archive Path
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.WIN_ARTIFACT }}
           path: ${{ env.WIN_ARTIFACT_PATH }}
           retention-days: 1
 
       - name: Upload Windows Archive as Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.WIN_ARCHIVE_ARTIFACT }}
           path: ${{ steps.create_windows_archive.outputs.archive_file }}
@@ -277,7 +277,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Download Artifact with Configuration Information
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.CONFIG_ARTIFACT }}
 
@@ -294,12 +294,12 @@ jobs:
       # Need commit history and tags for scripts/version.sh to work as expected
       # so use 0 for fetch-depth.
       - name: Clone Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Download Artifact with Converted Documents
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.DOC_ARTIFACT }}
 
@@ -327,14 +327,14 @@ jobs:
           echo archive_path= '${{ steps.create_mac_archive.outputs.archive_file }}' > $MAC_ARTIFACT_PATH
 
       - name: Upload Artifact with Mac Archive Path
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.MAC_ARTIFACT }}
           path: ${{ env.MAC_ARTIFACT_PATH }}
           retention-days: 1
 
       - name: Upload Mac Archive as Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.MAC_ARCHIVE_ARTIFACT }}
           path: ${{ steps.create_mac_archive.outputs.archive_file }}
@@ -346,7 +346,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download Artifact with Configuration Information
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.CONFIG_ARTIFACT }}
 
@@ -361,7 +361,7 @@ jobs:
           echo "draft=$draft" >> $GITHUB_OUTPUT
 
       - name: Download Artifact with Source Archive Path
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.SRC_ARTIFACT }}
 
@@ -372,12 +372,12 @@ jobs:
           echo "archive_path=$archive_path" >> $GITHUB_OUTPUT
 
       - name: Download Artifact with Source Archive
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.SRC_ARCHIVE_ARTIFACT }}
 
       - name: Download Artifact with Windows Archive Path
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.WIN_ARTIFACT }}
 
@@ -388,12 +388,12 @@ jobs:
           echo "archive_path=$archive_path" >> $GITHUB_OUTPUT
 
       - name: Download Artifact with Windows Archive
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.WIN_ARCHIVE_ARTIFACT }}
 
       - name: Download Artifact with Mac Archive Path
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.MAC_ARTIFACT }}
 
@@ -404,12 +404,12 @@ jobs:
           echo "archive_path=$archive_path" >> $GITHUB_OUTPUT
 
       - name: Download Artifact with Mac Archive
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.MAC_ARCHIVE_ARTIFACT }}
 
       - name: Populate Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.store_config.outputs.version }}
           name: ${{ steps.store_config.outputs.version }}

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -16,7 +16,7 @@ jobs:
           sudo apt-get install gcc-mingw-w64 automake autoconf make
 
       - name: Clone Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build
         run: |


### PR DESCRIPTION
See GitHub's notice here, https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/ , about the Node 16 to Node 20 transition.