### PR TITLE
Introduce object kind flag to mark special kinds used for smithed artifacts

### DIFF
--- a/lib/gamedata/object.txt
+++ b/lib/gamedata/object.txt
@@ -154,6 +154,10 @@ graphics:$:w
 # being created without also turning them into artifacts.  This flag
 # must be specified both here and in the artifact template.
 #
+# The 'SMITH_ART' flag indicates that this object kind should be used as
+# the kind for all smithed objects that have the same type ('ring' for
+# example) as this kind.
+#
 # The reason for having multiple 'ring' and
 # 'amulet' templates is to allow each 'special artifact' to
 # have a different 'color' and 'flavor', and also to allow the use of
@@ -262,7 +266,7 @@ weight:1
 cost:1000
 attack:0:0d0
 defence:0:0d0
-flags:INSTA_ART
+flags:INSTA_ART | SMITH_ART
 
 
 # A base amulet for self-made artifacts
@@ -276,7 +280,7 @@ weight:1
 cost:1000
 attack:0:0d0
 defence:0:0d0
-flags:INSTA_ART
+flags:INSTA_ART | SMITH_ART
 
 
 # The Mighty Hammer 'Grond'

--- a/src/list-kind-flags.h
+++ b/src/list-kind-flags.h
@@ -12,6 +12,7 @@
 KF(NONE,			"")
 KF(INSTA_ART,		"")
 KF(QUEST_ART,		"")
+KF(SMITH_ART,		"")
 KF(GOOD,			"")
 KF(SHOW_DICE,		"")
 KF(EASY_KNOW,		"")

--- a/src/obj-util.c
+++ b/src/obj-util.c
@@ -328,6 +328,27 @@ struct object_kind *lookup_kind(int tval, int sval)
 	return NULL;
 }
 
+/**
+ * Return the object kind that should be used as the basis for any smithed
+ * artifact belonging to the given tval.  If there is no such kind -
+ * indicating smithed artifacts should use a standard kind from that tval -
+ * return NULL.
+ */
+struct object_kind *lookup_selfmade_kind(int tval)
+{
+	int k;
+
+	for (k = 0; k < z_info->k_max; k++) {
+		struct object_kind *kind = &k_info[k];
+
+		if (kind->tval == tval
+				&& kf_has(kind->kind_flags, KF_SMITH_ART)) {
+			return kind;
+		}
+	}
+	return NULL;
+}
+
 struct object_kind *objkind_byid(int kidx) {
 	if (kidx < 0 || kidx >= z_info->k_max)
 		return NULL;

--- a/src/obj-util.h
+++ b/src/obj-util.h
@@ -37,6 +37,7 @@ bool is_unknown(const struct object *obj);
 unsigned check_for_inscrip(const struct object *obj, const char *inscrip);
 unsigned check_for_inscrip_with_int(const struct object *obj, const char *insrip, int *ival);
 struct object_kind *lookup_kind(int tval, int sval);
+struct object_kind *lookup_selfmade_kind(int tval);
 struct object_kind *objkind_byid(int kidx);
 const struct artifact *lookup_artifact_name(const char *name);
 struct ego_item *lookup_ego_item(const char *name, int tval, int sval);

--- a/src/ui-smith.c
+++ b/src/ui-smith.c
@@ -28,6 +28,7 @@
 #include "obj-pile.h"
 #include "obj-smith.h"
 #include "obj-tval.h"
+#include "obj-util.h"
 #include "object.h"
 #include "player-abilities.h"
 #include "player-calcs.h"
@@ -916,17 +917,27 @@ static bool artefact_action(struct menu *m, const ui_event *event, int oid)
  */
 static void artefact_menu(const char *name, int row)
 {
-	struct object_kind *kind = smith_obj->kind;
+	struct object_kind *kind;
 	struct menu menu;
 	menu_iter menu_f = { NULL, NULL, artefact_display, artefact_action, NULL };
 	region area = { COL_SMT2, ROW_SMT1, COL_SMT4 - COL_SMT2, MAX_SMITHING_TVALS };
 	int i;
 
-	if (!kind) return;
+	if (!smith_obj->kind) return;
+	/*
+	 * Some types of objects use a special base for all smithed artefacts.
+	 * All others use the base item already selected.
+	 */
+	kind = lookup_selfmade_kind(smith_obj->kind->tval);
+	if (!kind) {
+		kind = smith_obj->kind;
+	}
 
 	/* Mark as an artefact, remove any special item info */
+	if (smith_obj->ego || kind != smith_obj->kind) {
+		reset_smithing_objects(kind);
+	}
 	smith_obj->artifact = smith_art;
-	if (smith_obj->ego) reset_smithing_objects(kind);
 
 	my_strcpy(smith_art_name, format("of %s", player->full_name),
 			  sizeof(smith_art_name));


### PR DESCRIPTION
Use that for rings and amulets since Sil 1.3 does not use the base object's kind as the kind for the smithed object.  When resetting smithing objects for an artifact, do so before assigning the artifact field.  Resolves https://github.com/NickMcConnell/NarSil/issues/404 .