### PR TITLE
Better match Sil 1.3's summoning logic for roosts and webs

### DIFF
--- a/src/effect-handler-general.c
+++ b/src/effect-handler-general.c
@@ -780,10 +780,11 @@ bool effect_handler_SUMMON(effect_handler_context_t *context)
 		}
 	} else {
 		/* Summon some monsters */
-		while (summon_max) {
+		int itry = 0;
+		while (count < summon_max && itry < 1000) {
 			count += summon_specific(player->grid, player->depth + level_boost,
 									 summon_type);
-			summon_max--;
+			++itry;
 		}
 
 		/* Identify */

--- a/src/mon-summon.c
+++ b/src/mon-summon.c
@@ -345,7 +345,7 @@ int summon_specific(struct loc grid, int lev, int type)
 	get_mon_num_prep(summon_specific_okay);
 
 	/* Pick a monster, using the level calculation */
-	race = get_mon_num(lev, false, true, player->depth);
+	race = get_mon_num(lev, false, true, false);
 
 	/* Prepare allocation table */
 	get_mon_num_prep(NULL);


### PR DESCRIPTION
1) Retry up to 1000 times to get the requested number summoned (see cmd1.c:2937-2971 in Sil 1.3).
2) Set vault argument to false when calling get_mon_num() (see monster2.c:3268 in Sil 1.3).

Resolves https://github.com/NickMcConnell/NarSil/issues/430 .