### PR TITLE
Forget field of fire when cleaning up

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -2073,6 +2073,7 @@ void cleanup_angband(void)
 
 	/* Free the main cave */
 	if (cave) {
+		forget_fire(cave);
 		cave_free(cave);
 		cave = NULL;
 	}


### PR DESCRIPTION
Avoids possibility of assertion failure/out-of-bounds write if a character dies on a larger level and then, without exiting, starts a new game or reloads anoter save with a smaller level size.