### PR TITLE
Put stored corners for a vault just inside the vault's boundaries

### DIFF
--- a/src/gen-room.c
+++ b/src/gen-room.c
@@ -804,7 +804,7 @@ static bool build_vault_type(struct chunk *c, struct loc centre,
 	}
 
 	/* Make sure that the location is empty */
-	if (!solid_rock(c, y1 - 3, x1 - 3, y2 + 3,	x2 + 3)) {
+	if (!solid_rock(c, y1 - 2, x1 - 2, y2 + 2, x2 + 2)) {
 		return false;
 	}
 
@@ -814,8 +814,8 @@ static bool build_vault_type(struct chunk *c, struct loc centre,
 	}
 
 	/* Save the corner locations */
-	dun->corner[dun->cent_n].top_left = loc(x1, y1);
-	dun->corner[dun->cent_n].bottom_right = loc(x2, y2);
+	dun->corner[dun->cent_n].top_left = loc(x1 + 1, y1 + 1);
+	dun->corner[dun->cent_n].bottom_right = loc(x2 - 1, y2 - 1);
 
 	/* Save the room location */
 	dun->cent[dun->cent_n] = centre;


### PR DESCRIPTION
That matches Sil 1.3 (see its generate.c:2798-2802,2890-2894,3033-3037), where the corners are for a simple room (just inside its bounding walls), and should make tunneling attempts more likely to suceed.  Change the solid_rock() tests for vaults to match Sil 1.3's behavior for interesting rooms and lesser vaults.

For greater vaults, Sil 1.3 uses (y1 - 5, x1 - 5, y2 + 5, x2 + 5) as the bounds for the solid_rock() test (see its generate.c:3022).  Do not use that here as Sil 1.3's behavior is not consistent with its own limits on where the vault is placed on the level and would lead to possible out-of-bounds accesses to the level's arrays.