### PR TITLE
Simplify logic when tunnel's start is same as the end

### DIFF
--- a/src/gen-cave.c
+++ b/src/gen-cave.c
@@ -449,12 +449,9 @@ static bool tunnel_ok(struct chunk *c, struct loc grid1, struct loc grid2,
 		if (grid1.x < grid2.x) {
 			grid_lo = grid1;
 			grid_hi = grid2;
-		} else if (grid2.x < grid1.x) {
+		} else {
 			grid_lo = grid2;
 			grid_hi = grid1;
-		} else {
-			/* Same grid, no tunnel */
-			return false;
 		}
 	} else {
 		/* Vertical */
@@ -633,12 +630,9 @@ static int lay_tunnel(struct chunk *c, struct loc grid1, struct loc grid2,
 		if (grid1.x < grid2.x) {
 			grid_lo = grid1;
 			grid_hi = grid2;
-		} else if (grid2.x < grid1.x) {
+		} else {
 			grid_lo = grid2;
 			grid_hi = grid1;
-		} else {
-			/* Same grid, no tunnel (should be unnecessary) */
-			return ncnvt;
 		}
 	} else {
 		/* Vertical */


### PR DESCRIPTION
Makes comparisons with Sil 1.3 easier (no special handling of such tunnels there) and removes the asymmetric handling of the vertical and horizontal cases (only had special treatment of such tunnels in the horizontal case).  Does not appear to affect tunnel generation:  such tunnels are either prevented by the room layout or are eliminated by the other tests in tunnel_ok().