### PR TITLE
Disconnection statistics: use "rubble" for grids with rubble

### DIFF
--- a/src/wiz-stats.c
+++ b/src/wiz-stats.c
@@ -1943,7 +1943,7 @@ struct grid_count_aggregate {
 	struct i_sum_sum2 downstair;
 	struct d_sum_sum2 trap;
 	struct d_sum_sum2 forge;
-	struct d_sum_sum2 pass_rubble;
+	struct d_sum_sum2 rubble;
 	struct d_sum_sum2 open_door;
 	struct d_sum_sum2 closed_door;
 	struct d_sum_sum2 broken_door;
@@ -1967,8 +1967,8 @@ static void initialize_grid_count_aggregate(struct grid_count_aggregate *ga)
 	ga->trap.sum2 = 0.0;
 	ga->forge.sum = 0.0;
 	ga->forge.sum2 = 0.0;
-	ga->pass_rubble.sum = 0.0;
-	ga->pass_rubble.sum2 = 0.0;
+	ga->rubble.sum = 0.0;
+	ga->rubble.sum2 = 0.0;
 	ga->open_door.sum = 0.0;
 	ga->open_door.sum2 = 0.0;
 	ga->closed_door.sum = 0.0;
@@ -1995,7 +1995,7 @@ static void add_to_grid_count_aggregate(struct grid_count_aggregate *ga,
 	add_to_i_sum_sum2(&ga->downstair, gi->downstair);
 	add_to_d_sum_sum2(&ga->trap, gi->trap / area);
 	add_to_d_sum_sum2(&ga->forge, gi->forge / area);
-	add_to_d_sum_sum2(&ga->pass_rubble, gi->pass_rubble / area);
+	add_to_d_sum_sum2(&ga->rubble, gi->rubble / area);
 	add_to_d_sum_sum2(&ga->open_door, gi->open_door / area);
 	add_to_d_sum_sum2(&ga->closed_door, gi->closed_door / area);
 	add_to_d_sum_sum2(&ga->broken_door, gi->broken_door / area);
@@ -2397,12 +2397,12 @@ static void dump_generation_stats(ang_file *fo, const struct cgen_stats *gs)
 					gs->level_counts[0][i]));
 		}
 		file_put(fo, "\n");
-		file_put(fo, "parubb");
+		file_put(fo, "rubble");
 		for (j = 0; j < 3; ++j) {
 			file_putf(fo, "\t%.6f\t%.6f",
-				gs->ga[i][j].pass_rubble.sum /
+				gs->ga[i][j].rubble.sum /
 					gs->level_counts[0][i],
-				stddev_d_sum_sum2(gs->ga[i][j].pass_rubble,
+				stddev_d_sum_sum2(gs->ga[i][j].rubble,
 					gs->level_counts[0][i]));
 		}
 		file_put(fo, "\n");
@@ -2944,7 +2944,7 @@ void stat_grid_counter_simple(struct chunk *c, struct grid_counts counts[3])
 	counts[0].downstair = gpreds[2].in_vault_count;
 	counts[0].trap = gpreds[3].in_vault_count;
 	counts[0].forge = gpreds[4].in_vault_count;
-	counts[0].pass_rubble = gpreds[5].in_vault_count;
+	counts[0].rubble = gpreds[5].in_vault_count;
 	counts[0].open_door = gpreds[6].in_vault_count;
 	counts[0].closed_door = gpreds[7].in_vault_count;
 	counts[0].broken_door = gpreds[8].in_vault_count;
@@ -2958,7 +2958,7 @@ void stat_grid_counter_simple(struct chunk *c, struct grid_counts counts[3])
 	counts[1].downstair = gpreds[2].in_room_count;
 	counts[1].trap = gpreds[3].in_room_count;
 	counts[1].forge = gpreds[4].in_room_count;
-	counts[1].pass_rubble = gpreds[5].in_room_count;
+	counts[1].rubble = gpreds[5].in_room_count;
 	counts[1].open_door = gpreds[6].in_room_count;
 	counts[1].closed_door = gpreds[7].in_room_count;
 	counts[1].broken_door = gpreds[8].in_room_count;
@@ -2972,7 +2972,7 @@ void stat_grid_counter_simple(struct chunk *c, struct grid_counts counts[3])
 	counts[2].downstair = gpreds[2].in_other_count;
 	counts[2].trap = gpreds[3].in_other_count;
 	counts[2].forge = gpreds[4].in_other_count;
-	counts[2].pass_rubble = gpreds[5].in_other_count;
+	counts[2].rubble = gpreds[5].in_other_count;
 	counts[2].open_door = gpreds[6].in_other_count;
 	counts[2].closed_door = gpreds[7].in_other_count;
 	counts[2].broken_door = gpreds[8].in_other_count;

--- a/src/wizard.h
+++ b/src/wizard.h
@@ -53,7 +53,7 @@ struct grid_counts {
 	int downstair;
 	int trap;
 	int forge;
-	int pass_rubble;
+	int rubble;
 	int open_door;
 	int closed_door;
 	int broken_door;


### PR DESCRIPTION
There are not two types of rubble like Vanilla Angband, so "pass_rubble" in the structure and "parubb" in the output file could be confusing.