### PR TITLE
ui-term: remove attr_blank & char_blank

### DIFF
--- a/src/main-gcu.c
+++ b/src/main-gcu.c
@@ -1184,10 +1184,6 @@ static errr term_data_init_gcu(term_data *td, int rows, int cols, int y, int x)
 	/* Avoid bottom right corner */
 	t->icky_corner = true;
 
-	/* Erase with "white space" */
-	t->attr_blank = COLOUR_WHITE;
-	t->char_blank = ' ';
-
 	/* Differentiate between BS/^h, Tab/^i, etc. */
 	t->complex_input = true;
 

--- a/src/main-nds.c
+++ b/src/main-nds.c
@@ -468,10 +468,6 @@ static errr Term_wipe_nds(int x, int y, int n)
  * default "spaces", and all other colors should be drawn in
  * the "normal" color in a monochrome environment.
  *
- * Note that if you have changed the "attr_blank" to something
- * which is not black, then this function must be able to draw
- * the resulting "blank" correctly.
- *
  * Note that this function must correctly handle "black" text if
  * the "always_text" flag is set, if this flag is not set, all the
  * "black" text will be handled by the "Term_wipe_xxx()" hook.

--- a/src/main-sdl.c
+++ b/src/main-sdl.c
@@ -3214,10 +3214,6 @@ static void term_data_link_sdl(term_window *win)
 	/* Use a "software" cursor */
 	t->soft_cursor = true;
 
-	/* Erase with "white space" */
-	t->attr_blank = COLOUR_WHITE;
-	t->char_blank = ' ';
-
 	/* Never refresh one row */
 	t->never_frosh = true;
 

--- a/src/main-sdl2.c
+++ b/src/main-sdl2.c
@@ -61,10 +61,6 @@
 #define SUBWINDOW_KEYQ_SIZE(subwindow_ptr) \
 	((subwindow_ptr)->index == MAIN_SUBWINDOW ? 1024 : 32)
 
-#define DEFAULT_ATTR_BLANK \
-	COLOUR_WHITE
-#define DEFAULT_CHAR_BLANK ' '
-
 #define DEFAULT_DISPLAY 0
 
 #define DEFAULT_CONFIG_FILE "sdl2init.txt"
@@ -877,7 +873,7 @@ static void render_glyph_mono(const struct window *window,
 		const struct font *font, SDL_Texture *dst_texture,
 		int x, int y, const SDL_Color *fg, uint32_t codepoint)
 {
-	if (codepoint == DEFAULT_CHAR_BLANK) {
+	if (codepoint == ' ') {
 		return;
 	}
 
@@ -5442,9 +5438,6 @@ static void link_term(struct subwindow *subwindow)
 	subwindow->term->soft_cursor = true;
 	subwindow->term->complex_input = true;
 	subwindow->term->never_frosh = true;
-
-	subwindow->term->attr_blank = DEFAULT_ATTR_BLANK;
-	subwindow->term->char_blank = DEFAULT_CHAR_BLANK;
 
 	subwindow->term->xtra_hook = term_xtra_hook;
 	subwindow->term->curs_hook = term_curs_hook;

--- a/src/main-win.c
+++ b/src/main-win.c
@@ -2575,10 +2575,6 @@ static void term_data_link(term_data *td)
 	/* Use "Term_pict" for "graphic" data */
 	t->higher_pict = true;
 
-	/* Erase with "white space" */
-	t->attr_blank = COLOUR_WHITE;
-	t->char_blank = ' ';
-
 #if 0
 	/* Prepare the init/nuke hooks */
 	t->init_hook = Term_init_win;

--- a/src/main-x11.c
+++ b/src/main-x11.c
@@ -2558,10 +2558,6 @@ static errr term_data_init(term_data *td, int i)
 	/* Use a "soft" cursor */
 	t->soft_cursor = true;
 
-	/* Erase with "white space" */
-	t->attr_blank = COLOUR_WHITE;
-	t->char_blank = ' ';
-
 	/* Differentiate between BS/^h, Tab/^i, etc. */
 	t->complex_input = true;
 

--- a/src/main-xxx.c
+++ b/src/main-xxx.c
@@ -469,10 +469,6 @@ static errr Term_wipe_xxx(int x, int y, int n)
  * default "spaces", and all other colors should be drawn in
  * the "normal" color in a monochrome environment.
  *
- * Note that if you have changed the "attr_blank" to something
- * which is not black, then this function must be able to draw
- * the resulting "blank" correctly.
- *
  * Note that this function must correctly handle "black" text if
  * the "always_text" flag is set, if this flag is not set, all the
  * "black" text will be handled by the "Term_wipe_xxx()" hook.
@@ -586,10 +582,6 @@ static void term_data_link(int i)
 	/* Ignore the "TERM_XTRA_FROSH" action XXX XXX XXX */
 	/* This may make things slightly more efficient. */
 	/* t->never_frosh = true; */
-
-	/* Erase with "white space" XXX XXX XXX */
-	/* t->attr_blank = COLOUR_WHITE; */
-	/* t->char_blank = ' '; */
 
 	/* Prepare the init/nuke hooks */
 	t->init_hook = Term_init_xxx;

--- a/src/ui-command.c
+++ b/src/ui-command.c
@@ -279,8 +279,8 @@ static void screenshot_term_query(int wid, int hgt, int x, int y, int *a, wchar_
 		if (srcx < wid && srcy < hgt - ROW_BOTTOM_MAP) {
 			(void) Term_what(srcx, srcy, a, c);
 		} else {
-			*a = Term->attr_blank;
-			*c = Term->char_blank;
+			*a = COLOUR_WHITE;
+			*c = ' ';
 		}
 	}
 }
@@ -384,8 +384,8 @@ void html_screenshot(const char *path, int mode, term *other_term)
 					Term_activate(main_term);
 				}
 			} else {
-				a = main_term->attr_blank;
-				c = main_term->char_blank;
+				a = COLOUR_WHITE;
+				c = ' ';
 			}
 
 			/* Set the foreground and background */

--- a/src/ui-map.c
+++ b/src/ui-map.c
@@ -636,12 +636,11 @@ static void prt_map_aux(void)
 				/* Check bounds */
 				if (!square_in_bounds(cave, loc(x, y))) {
 					Term_queue_char(t, vx, vy,
-						t->attr_blank, t->char_blank,
+						COLOUR_WHITE, ' ',
 						0, 0);
 					if (tile_width > 1 || tile_height > 1) {
 						Term_big_queue_char(t, vx, vy,
-							clipy, t->attr_blank,
-							t->char_blank, 0, 0);
+							clipy, COLOUR_WHITE, ' ', 0, 0);
 					}
 					continue;
 				}
@@ -657,15 +656,15 @@ static void prt_map_aux(void)
 			}
 			/* Clear partial tile at the end of each line. */
 			for (; vx < t->wid; ++vx) {
-				Term_queue_char(t, vx, vy, t->attr_blank,
-					t->char_blank, 0, 0);
+				Term_queue_char(t, vx, vy, COLOUR_WHITE,
+					' ', 0, 0);
 			}
 		}
 		/* Clear row of partial tiles at the bottom. */
 		for (; vy < t->hgt; ++vy) {
 			for (vx = 0; vx < t->wid; ++vx) {
-				Term_queue_char(t, vx, vy, t->attr_blank,
-					t->char_blank, 0, 0);
+				Term_queue_char(t, vx, vy, COLOUR_WHITE,
+					' ', 0, 0);
 			}
 		}
 	}

--- a/src/ui-term.c
+++ b/src/ui-term.c
@@ -1087,7 +1087,7 @@ static void Term_fresh_row_both(int y, int x1, int x2)
 	int fx = 0;
 
 	/* Pending attr */
-	int fa = Term->attr_blank;
+	int fa = COLOUR_WHITE;
 
 	int oa;
 	wchar_t oc;
@@ -1254,7 +1254,7 @@ static void Term_fresh_row_both_dblh(int y, int x1, int x2, int *pr_drw)
 	int fx = 0;
 
 	/* Pending attr */
-	int fa = Term->attr_blank;
+	int fa = COLOUR_WHITE;
 
 	if (y < Term->hgt - tile_height) {
 		scr_aa_nr = Term->scr->a[y + tile_height];
@@ -1487,7 +1487,7 @@ static void Term_fresh_row_text(int y, int x1, int x2)
 	int fx = 0;
 
 	/* Pending attr */
-	int fa = Term->attr_blank;
+	int fa = COLOUR_WHITE;
 
 	int oa;
 	wchar_t oc;
@@ -1670,12 +1670,10 @@ bool smlcurs = true;
  * high-bit set) to be sent (one pair at a time) to the "Term->pict_hook"
  * hook, which can draw these pairs in whatever way it would like.
  *
- * Normally, the "Term_wipe()" function is used only to display "blanks"
- * that were induced by "Term_clear()" or "Term_erase()", and then only
- * if the "attr_blank" and "char_blank" fields have not been redefined
- * to use "white space" instead of the default "black space".  Actually,
- * the "Term_wipe()" function is used to display all "black" text, such
- * as the default "spaces" created by "Term_clear()" and "Term_erase()".
+ * Normally, the "Term_wipe()" function is used only to display "blanks" that
+ * were induced by "Term_clear()" or "Term_erase()". Actually, the
+ * "Term_wipe()" function is used to display all "black" text, such as the
+ * default "spaces" created by "Term_clear()" and "Term_erase()".
  *
  * Note that the "Term->always_text" flag will disable the use of the
  * "Term_wipe()" function hook entirely, and force all text, even text
@@ -1685,10 +1683,6 @@ bool smlcurs = true;
  * Note that the "Term->always_pict" flag will disable the use of the
  * "Term_wipe()" function entirely, and force everything, even text
  * drawn in the attr "black", to be explicitly drawn.
- *
- * Note that if no "black" text is ever drawn, and if "attr_blank" is
- * not "zero", then the "Term_wipe" hook will never be used, even if
- * the "Term->always_text" flag is not set.
  *
  * This function does nothing unless the "Term" is "mapped", which allows
  * certain systems to optimize the handling of "closed" windows.
@@ -1754,9 +1748,6 @@ errr Term_fresh(void)
 
 	/* Handle "total erase" */
 	if (Term->total_erase) {
-		int na = Term->attr_blank;
-		wchar_t nc = Term->char_blank;
-
 		/* Physically erase the entire window */
 		Term_xtra(TERM_XTRA_CLEAR, 0);
 
@@ -1775,11 +1766,11 @@ errr Term_fresh(void)
 			/* Wipe each column */
 			for (x = 0; x < w; x++) {
 				/* Wipe each grid */
-				*aa++ = na;
-				*cc++ = nc;
+				*aa++ = COLOUR_WHITE;
+				*cc++ = ' ';
 
-				*taa++ = na;
-				*tcc++ = nc;
+				*taa++ = COLOUR_WHITE;
+				*tcc++ = ' ';
 			}
 		}
 
@@ -2263,9 +2254,6 @@ errr Term_erase(int x, int y, int n)
 	int x1 = -1;
 	int x2 = -1;
 
-	int na = Term->attr_blank;
-	wchar_t nc = Term->char_blank;
-
 	int *scr_aa;
 	wchar_t *scr_cc;
 
@@ -2291,11 +2279,11 @@ errr Term_erase(int x, int y, int n)
 		wchar_t oc = scr_cc[x];
 
 		/* Hack -- Ignore "non-changes" */
-		if ((oa == na) && (oc == nc)) continue;
+		if ((oa == COLOUR_WHITE) && (oc == ' ')) continue;
 
 		/* Save the "literal" information */
-		scr_aa[x] = na;
-		scr_cc[x] = nc;
+		scr_aa[x] = COLOUR_WHITE;
+		scr_cc[x] = ' ';
 
 		scr_taa[x] = 0;
 		scr_tcc[x] = 0;
@@ -2335,9 +2323,6 @@ errr Term_clear(void)
 	int w = Term->wid;
 	int h = Term->hgt;
 
-	int na = Term->attr_blank;
-	wchar_t nc = Term->char_blank;
-
 	/* Cursor usable */
 	Term->scr->cu = 0;
 
@@ -2353,8 +2338,8 @@ errr Term_clear(void)
 
 		/* Wipe each column */
 		for (x = 0; x < w; x++) {
-			scr_aa[x] = na;
-			scr_cc[x] = nc;
+			scr_aa[x] = COLOUR_WHITE;
+			scr_cc[x] = ' ';
 
 			scr_taa[x] = 0;
 			scr_tcc[x] = 0;
@@ -3139,10 +3124,6 @@ errr term_init(term *t, int w, int h, int k)
 
 	/* Force "total erase" */
 	t->total_erase = true;
-
-	/* Default "blank" */
-	t->attr_blank = 0;
-	t->char_blank = L' ';
 
 	/* No saves yet */
 	t->saved = 0;

--- a/src/ui-term.h
+++ b/src/ui-term.h
@@ -110,13 +110,6 @@ struct term_win
  *	- Flag "never_frosh"
  *	  Never call the "TERM_XTRA_FROSH" action
  *
- *
- *	- Value "attr_blank"
- *	  Use this "attr" value for "blank" grids
- *
- *	- Value "char_blank"
- *	  Use this "char" value for "blank" grids
- *
  *	- Flag "complex_input"
  *	  Distinguish between Enter/^m/^j, Tab/^i, etc.
  *
@@ -185,9 +178,6 @@ struct term
 	bool never_bored;
 	bool never_frosh;
 	int sidebar_mode;
-
-	int attr_blank;
-	wchar_t char_blank;
 
 	bool complex_input;
 


### PR DESCRIPTION
On every platform, these were set to COLOUR_WHITE and ' ' respectively; replace them throughout with their manifest constants and remove them. It's not very obvious why they were originally added, since they were only used internally to Angband and never actually drawn on the screen - rather, any cell drawn with attr_blank and char_blank was considered empty and cleared in a platform-specific way. Making them configurable per-platform when in fact they were not exposed to the platform is somewhat puzzling.