### PR TITLE
Get working sound with Makefile.msys2.sdl2; update the comments in that file. (#5492)

### DIFF
--- a/docs/hacking/compiling.rst
+++ b/docs/hacking/compiling.rst
@@ -446,10 +446,10 @@ Install the dependencies by::
 
 Additional dependencies for SDL2 client::
 
-	pacman -S mingw-w64-x86_64-SDL2 mingw-w64-x86_64-SDL2_gfx \
-		  mingw-w64-x86_64-SDL2_image mingw-w64-x86_64-SDL2_ttf
+	pacman -S mingw-w64-x86_64-SDL2 mingw-w64-x86_64-SDL2_image \
+		mingw-w64-x86_64-SDL2_ttf
 
-Then run the following to compile with ncurse::
+Then run the following to compile with ncurses::
 
 	cd src
 	make -f Makefile.msys2
@@ -459,11 +459,22 @@ For SDL2, do::
 	cd src
 	make -f Makefile.msys2.sdl2
 
-Go to the root of the source directory and start angband by::
+Very recent versions of Makefile.msys2.sdl2 allow use of SDL2 sound; to build
+with that you'll need SDL2_mixer installed in addtion to the other SDL2
+libraries mentioned above::
+
+	pacman -S mingw-w64-x86_64-SDL2_mixer
+
+Then the executable with SDL2 sound support can be built with::
+
+	cd src
+	make -f Makefile.msys2.sdl2 SOUND=yes
+
+Once built, go to the root of the source directory and start angband by::
 
 	./angband.exe -uPLAYER
 
-The ncurse client may not be able to start properly from msys2 shell, try::
+The ncurses client may not be able to start properly from msys2 shell, try::
 
 	start bash
 

--- a/src/Makefile.msys2.sdl2
+++ b/src/Makefile.msys2.sdl2
@@ -1,11 +1,20 @@
-# File: Makefile.sdl2
+# File: Makefile.msys2.sdl2
 # Makefile for compiling Angband with SDL2.
 #
 # This makefile requires GNU make.
 #
-# This makefile is intended for use with Unix machines that have SDL2 library.
-# The video subsystem requires libsdl2, libsdl2-ttf and libsdl2-image.
-# The sound subsystem requires libsdl2 and libsdl2-mixer.
+# This makefile is intended for use with GNU make and mingw in the msys2
+# environment for Windows (within msys2 run "pacman -S mingw-w64-x86_64-gcc ;
+# pacman -S make" to install those).
+#
+# The video subsystem requires libsdl2, libsdl2-ttf and libsdl2-image
+# (within msys2 run "pacman -S mingw-w64-x86_64-SDL2 ;
+# pacman -S mingw-w64-x86_64-SDL2_ttf ; pacman -S mingw-w64-x86_64-SDL2_image"
+# to install those).
+#
+# The sound subsystem requires libsdl2 and libsdl2-mixer (libsdl2 is already
+# installed for the video subsystem; to install libsdl2-mixer run
+# "pacman -S mingw-w64-x86_64-SDL2_mixer" in msys2).
 #
 # If you want only video (but not sound), use it like this:
 # (from angband directory)
@@ -13,7 +22,8 @@
 # cd src
 # make -f Makefile.msys2.sdl
 #
-# TODO: sound is not working for windows build
+# To also have SDL2 sound, change the second of those commands to:
+# make -f Makefile.msys2.sdl2 SOUND=yes
 #
 
 # By default, copy the executable to ../ so that
@@ -53,10 +63,18 @@ VIDEO_sdl2 := -DUSE_SDL2 \
 	-loleaut32 \
 	-lwinmm \
 
-## Support SDL_mixer for sound, doesn't work yet
-#SOUND_sdl2 := -DSOUND_SDL -DSOUND \
-#	$(shell sdl2-config --cflags) \
-#	$(shell sdl2-config --libs) -lSDL2_mixer
+## Support SDL_mixer for sound
+ifdef SOUND
+SOUND_sdl2 := -DSOUND_SDL2 -DSOUND \
+	$(shell sdl2-config --cflags) \
+	$(shell sdl2-config --libs) -lSDL2_mixer \
+	-lmpg123 \
+	-lopusfile \
+	-lopus \
+	-logg \
+	-lshlwapi \
+	-lwinmm
+endif
 
 # Compiler to use
 CC := gcc
@@ -80,10 +98,9 @@ LDFLAGS := -lm
 
 # Frontends to compile
 MODULES := $(VIDEO_sdl2)
-
-#ifdef SOUND
-#	MODULES += $(SOUND_sdl2)
-#endif
+ifdef SOUND
+MODULES += $(SOUND_sdl2)
+endif
 
 # Extract CFLAGS and LDFLAGS from the module definitions
 CFLAGS += $(patsubst -l%,,$(MODULES))
@@ -101,7 +118,7 @@ EXE := $(PROGNAME)
 OBJS := main.o main-sdl2.o $(BASEOBJS)
 
 ifdef SOUND
-	OBJS += snd-sdl.o
+OBJS += snd-sdl.o
 endif
 
 # Build the "Angband" program


### PR DESCRIPTION
* Get working sound with Makefile.msys2.sdl2; update the comments in that file.

* Change documentation about compiling the SDL2 front end under msys2 to add how to build with sound support and drop the mention of SDL2_gfx (that library isn't needed).