### PR TITLE
Add printf-style format checking for gcc and clang

### DIFF
--- a/src/h-basic.h
+++ b/src/h-basic.h
@@ -129,7 +129,11 @@
 # include <unistd.h>
 #endif
 
-
+#if defined(__GNUC__) || defined(__clang__)
+#define ATTRIBUTE __attribute__
+#else
+#define ATTRIBUTE(x)
+#endif
 
 /**
  * ------------------------------------------------------------------------

--- a/src/z-file.h
+++ b/src/z-file.h
@@ -201,7 +201,8 @@ bool file_put(ang_file *f, const char *buf);
 /**
  * Format (using strnfmt) the given args, and then call file_put().
  */
-bool file_putf(ang_file *f, const char *fmt, ...);
+bool file_putf(ang_file *f, const char *fmt, ...)
+	ATTRIBUTE ((format (printf, 2, 3)));
 bool file_vputf(ang_file *f, const char *fmt, va_list vp);
 
 

--- a/src/z-form.h
+++ b/src/z-form.h
@@ -41,7 +41,8 @@ extern size_t vstrnfmt(char *buf, size_t max, const char *fmt, va_list vp);
 /**
  * Simple interface to "vstrnfmt()"
  */
-extern size_t strnfmt(char *buf, size_t max, const char *fmt, ...);
+extern size_t strnfmt(char *buf, size_t max, const char *fmt, ...)
+	ATTRIBUTE ((format (printf, 3, 4)));
 
 /**
  * Format arguments into a static resizing buffer
@@ -56,22 +57,25 @@ extern void vformat_kill(void);
 /**
  * Append a formatted string to another string
  */
-extern void strnfcat(char *str, size_t max, size_t *end, const char *fmt, ...);
+extern void strnfcat(char *str, size_t max, size_t *end, const char *fmt, ...)
+	ATTRIBUTE ((format (printf, 4, 5)));
 
 /**
  * Simple interface to "vformat()"
  */
-extern char *format(const char *fmt, ...);
+extern char *format(const char *fmt, ...)
+	ATTRIBUTE ((format (printf, 1, 2)));
 
 /**
  * Vararg interface to "plog()", using "format()"
  */
-extern void plog_fmt(const char *fmt, ...);
+extern void plog_fmt(const char *fmt, ...)
+	ATTRIBUTE ((format (printf, 1, 2)));
 
 /**
  * Vararg interface to "quit()", using "format()"
  */
-extern void quit_fmt(const char *fmt, ...);
-
+extern void quit_fmt(const char *fmt, ...)
+	ATTRIBUTE ((format (printf, 1, 2)));
 
 #endif /* INCLUDED_Z_FORM_H */

--- a/src/z-textblock.h
+++ b/src/z-textblock.h
@@ -29,8 +29,10 @@ textblock *textblock_new(void);
 void textblock_free(textblock *tb);
 
 
-void textblock_append(textblock *tb, const char *fmt, ...);
-void textblock_append_c(textblock *tb, int attr, const char *fmt, ...);
+void textblock_append(textblock *tb, const char *fmt, ...)
+	ATTRIBUTE ((format (printf, 2, 3)));
+void textblock_append_c(textblock *tb, int attr, const char *fmt, ...)
+	ATTRIBUTE ((format (printf, 3, 4)));
 void textblock_append_pict(textblock *tb, int attr, int c);
 void textblock_append_textblock(textblock *tb, const textblock *tba);
 
@@ -49,9 +51,12 @@ extern int text_out_indent;
 extern int text_out_pad;
 
 extern void text_out_to_file(int attr, const char *str);
-extern void text_out(const char *fmt, ...);
-extern void text_out_c(int a, const char *fmt, ...);
-extern void text_out_e(const char *fmt, ...);
+extern void text_out(const char *fmt, ...)
+	ATTRIBUTE ((format (printf, 1, 2)));
+extern void text_out_c(int a, const char *fmt, ...)
+	ATTRIBUTE ((format (printf, 2, 3)));
+extern void text_out_e(const char *fmt, ...)
+	ATTRIBUTE ((format (printf, 1, 2)));
 
 typedef void (*text_writer)(ang_file *f);
 errr text_lines_to_file(const char *path, text_writer writer);


### PR DESCRIPTION
Cherry-picked from Vanilla Angband's 838f0f3030c3dcc1dbcbdb5daa565743a454490a which was originally written by Elly Fong-Jones, efongjones@gmail.com .