### PR TITLE
Avoid memory leak on parsing error for blow method's action string

### DIFF
--- a/src/mon-init.c
+++ b/src/mon-init.c
@@ -175,10 +175,12 @@ static enum parser_error parse_meth_message_type(struct parser *p)
 static enum parser_error parse_meth_act_msg(struct parser *p) {
 	const char *message = parser_getstr(p, "act");
 	struct blow_method *meth = parser_priv(p);
-	struct blow_message *msg = mem_zalloc(sizeof(*msg));
-	if (!meth)
-		return PARSE_ERROR_MISSING_RECORD_HEADER;
+	struct blow_message *msg;
 
+	if (!meth) {
+		return PARSE_ERROR_MISSING_RECORD_HEADER;
+	}
+	msg = mem_zalloc(sizeof(*msg));
 	msg->act_msg = string_make(message);
 	msg->next = meth->messages;
 	meth->messages = msg;


### PR DESCRIPTION
Cherry-picked from Vanilla Angband's e3dd53200d001c97c3b4e2ff4a67299a24118c83 .