### PR TITLE
SDL2: fix handling of '=' key

### DIFF
--- a/src/main-sdl2.c
+++ b/src/main-sdl2.c
@@ -3555,6 +3555,7 @@ static bool handle_text_input(const SDL_TextInputEvent *input)
 			case '-':
 			case '+':
 			case '.':
+			case '=':
 				return false;
 		}
 	}


### PR DESCRIPTION
Resolves animal_waves report, http://angband.oook.cz/forum/showpost.php?p=157853&postcount=36 , of not being able to edit keymaps with the SDL2 front end.