### PR TITLE
Port Vanilla Angband's removal of second level check for instant artifacts

### DIFF
--- a/src/obj-make.c
+++ b/src/obj-make.c
@@ -516,15 +516,6 @@ static struct object *make_artifact_special(int level)
 		/* Artifact "rarity roll" */
 		if (!one_in_(art->rarity)) continue;
 
-		/* Enforce minimum "object" level (loosely) */
-		if (kind->level > level) {
-			/* Get the "out-of-depth factor" */
-			int d = (kind->level - level) * 5;
-
-			/* Roll for out-of-depth creation */
-			if (randint0(d) != 0) continue;
-		}
-
 		/* Assign the template */
 		new_obj = object_new();
 		object_prep(new_obj, kind, art->level, RANDOMISE);


### PR DESCRIPTION
Should also improve consistency with Sil 1.3 (see its object2.c:1860-1872 where there is one check against the artifact's level and none for the base object's level).