### PR TITLE
Allow an instance of a command to marked as a background command so i…

### DIFF
--- a/src/cmd-cave.c
+++ b/src/cmd-cave.c
@@ -1851,6 +1851,12 @@ void move_player(int dir, bool disarm)
 			/* Update view */
 			update_view(cave, player);
 			cmdq_push(CMD_AUTOPICKUP);
+			/*
+			 * The autopickup is a side effect of the move:  whatever
+			 * command triggered the move will be the target for CMD_REPEAT
+			 * rather than repeating the autopickup.
+			 */
+			cmdq_peek()->is_background_command = true;
 		}
 	}
 

--- a/src/cmd-core.c
+++ b/src/cmd-core.c
@@ -203,6 +203,39 @@ static struct command cmd_queue[CMD_QUEUE_SIZE];
 static bool repeat_prev_allowed = false;
 static bool repeating = false;
 
+
+/**
+ * Locate and return the index of the first previous command that is an
+ * appropriate target for CMD_REPEAT.  If no such command is available,
+ * return a negative value.
+ */
+static int cmdq_find_repeat_target_index(void)
+{
+	int target = cmd_head - 1;
+
+	while (1) {
+		if (target < 0) target = CMD_QUEUE_SIZE - 1;
+
+		if (target == cmd_tail) {
+			break;
+		}
+		/*
+		 * Only repeat a command that has not been marked
+		 * as a background command (i.e. it is not a side
+		 * effect of something else).
+		 */
+		if (!cmd_queue[target].is_background_command) {
+			if (cmd_queue[target].code != CMD_NULL) {
+				return target;
+			}
+			break;
+		}
+		/* Keep looking. */
+		--target;
+	}
+	return -1;
+}
+
 struct command *cmdq_peek(void)
 {
 	return &cmd_queue[prev_cmd_idx(cmd_head)];
@@ -221,17 +254,19 @@ errr cmdq_push_copy(struct command *cmd)
 	/* Insert command into queue. */
 	if (cmd->code != CMD_REPEAT) {
 		cmd_queue[cmd_head] = *cmd;
+	} else if (!repeat_prev_allowed) {
+		return 1;
 	} else {
-		int cmd_prev = cmd_head - 1;
+		int idx_to_repeat = cmdq_find_repeat_target_index();
 
-		if (!repeat_prev_allowed) return 1;
-
-		/* If we're repeating a command, we duplicate the previous command 
-		   in the next command "slot". */
-		if (cmd_prev < 0) cmd_prev = CMD_QUEUE_SIZE - 1;
-		
-		if (cmd_queue[cmd_prev].code != CMD_NULL)
-			cmd_queue[cmd_head] = cmd_queue[cmd_prev];
+		if (idx_to_repeat < 0) {
+			return 1;
+		}
+		/*
+		 * If we're repeating a command, we duplicate the previous
+		 * command in the next command "slot".
+		 */
+		cmd_queue[cmd_head] = cmd_queue[idx_to_repeat];
 	}
 
 	/* Advance point in queue, wrapping around at the end */
@@ -316,6 +351,7 @@ errr cmdq_push_repeat(cmd_code c, int nrepeats)
 		.context = CTX_INIT,
 		.code = CMD_NULL,
 		.nrepeats = 0,
+		.is_background_command = false,
 		.arg = { { 0 } }
 	};
 

--- a/src/cmd-core.h
+++ b/src/cmd-core.h
@@ -235,6 +235,12 @@ struct command {
 	/* Number of times to attempt to repeat command. */
 	int nrepeats;
 
+	/*
+	 * Whether this command should be skipped when looking for CMD_REPEAT's
+	 * target.
+	 */
+	bool is_background_command;
+
 	/* Arguments */
 	struct cmd_arg arg[CMD_MAX_ARGS];
 };

--- a/src/obj-ignore.c
+++ b/src/obj-ignore.c
@@ -557,6 +557,8 @@ void ignore_drop(struct player *p)
 
 		/* Check for !d (no drop) inscription */
 		if (!check_for_inscrip(obj, "!d") && !check_for_inscrip(obj, "!*")) {
+			struct command *drop_cmd;
+
 			/* Confirm the drop if the item is equipped. */
 			if (object_is_equipped(p->body, obj)) {
 				if (!verify_object("Really take off and drop", obj, p)) {
@@ -580,8 +582,18 @@ void ignore_drop(struct player *p)
 			/* We're allowed to drop it. */
 			p->upkeep->dropping = true;
 			cmdq_push(CMD_DROP);
-			cmd_set_arg_item(cmdq_peek(), "item", obj);
-			cmd_set_arg_number(cmdq_peek(), "quantity", obj->number);
+			drop_cmd = cmdq_peek();
+			assert(drop_cmd);
+			cmd_set_arg_item(drop_cmd, "item", obj);
+			cmd_set_arg_number(drop_cmd, "quantity",
+				obj->number);
+			/*
+			 * This drop is a side effect:  whatever
+			 * command triggered it will be the target
+			 * for CMD_REPEAT rather than repeating the
+			 * drop.
+			 */
+			drop_cmd->is_background_command = true;
 		}
 	}
 


### PR DESCRIPTION
…t won't be used as the target for CMD_REPEAT. Use that for CMD_AUTOPICKUP triggered by a move or CMD_DROP triggered by a change to inscriptions. Resolves https://github.com/NickMcConnell/FAangband/issues/349 .