### PR TITLE
Get rid of misleading "no player frontends" warning when cross-…

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -612,12 +612,8 @@ else
 fi
 
 if test "$enable_win" = "yes"; then
-	if test "$with_sdl" = "no"; then
-		echo "- Windows                                 No; missing libraries"
-	else
-		echo "- Windows                                 Yes"
-		local_player_frontends="$local_player_frontends"+
-	fi
+	echo "- Windows                                 Yes"
+	local_player_frontends="$local_player_frontends"+
 else
 	echo "- Windows                                 Disabled"
 fi


### PR DESCRIPTION
…compiling the windows frontend with the configure script.