### PR TITLE
Refactor cmd_get_spell(), get_spell(), and get_spell_hook to allow re…

### DIFF
--- a/src/cmd-core.c
+++ b/src/cmd-core.c
@@ -426,11 +426,21 @@ void cmd_disable_repeat_floor_item(void)
 	cmd_prev = cmd_head - 1;
 	if (cmd_prev < 0) cmd_prev = CMD_QUEUE_SIZE - 1;
 	if (cmd_queue[cmd_prev].code != CMD_NULL) {
-		struct object *obj;
+		struct command *cmd = &cmd_queue[cmd_prev];
+		int i = 0;
 
-		if (cmd_get_arg_item(&cmd_queue[cmd_prev], "item", &obj) == CMD_OK
-				&& (obj->grid.x != 0 || obj->grid.y != 0)) {
-			repeat_prev_allowed = false;
+		while (1) {
+			if (i >= CMD_MAX_ARGS) {
+				break;
+			}
+			if (cmd->arg[i].type == arg_ITEM
+					&& cmd->arg[i].data.obj
+					&& (cmd->arg[i].data.obj->grid.x != 0
+					|| cmd->arg[i].data.obj->grid.y != 0)) {
+				repeat_prev_allowed = false;
+				break;
+			}
+			++i;
 		}
 	}
 }
@@ -547,11 +557,31 @@ int cmd_get_arg_choice(struct command *cmd, const char *arg, int *choice)
 
 /**
  * Get a spell from the user, trying the command first but then prompting
+ *
+ * \param cmd is the command to use.
+ * \param arg is the name of the command's argument that stores the spell's
+ * index.
+ * \param p is the player.
+ * \param spell is dereferenced and set to the index of the spell selected.
+ * \param verb is the string describing the action for which the spell is
+ * requested.  It is typically "cast" or "study".
+ * \param book_filter is the function (if any) to test that an object is
+ * appropriate for use as a spellbook by the player.
+ * \param book_error is the message to display if no valid book is available.
+ * If NULL, no message will be displayed.
+ * \param spell_filter is the function to call to test if a spell is a valid
+ * selection for the request.
+ * \param spell_error is the message to display if no valid spell is available.
+ * If NULL, no message will be displayed.
+ * \return CMD_OK if a valid spell index was assigned to *spell or
+ * CMD_ARG_ABORTED if no valid spell index was assigned to *spell.
  */
 int cmd_get_spell(struct command *cmd, const char *arg, struct player *p,
 		int *spell,
-		const char *verb, item_tester book_filter, const char *error,
-		bool (*spell_filter)(const struct player *p, int spell))
+		const char *verb, item_tester book_filter,
+		const char *book_error,
+		bool (*spell_filter)(const struct player *p, int spell),
+		const char *spell_error)
 {
 	struct object *book;
 
@@ -564,14 +594,15 @@ int cmd_get_spell(struct command *cmd, const char *arg, struct player *p,
 
 	/* See if we've been given a book to look at */
 	if (cmd_get_arg_item(cmd, "book", &book) == CMD_OK) {
-		*spell = get_spell_from_book(p, verb, book, error,
+		*spell = get_spell_from_book(p, verb, book, spell_error,
 			spell_filter);
 	} else {
-		*spell = get_spell(p, verb, book_filter, cmd->code, error,
-			spell_filter);
+		*spell = get_spell(p, verb, book_filter, cmd->code, book_error,
+			spell_filter, spell_error, &book);
 	}
 
 	if (*spell >= 0) {
+		cmd_set_arg_item(cmd, "book", book);
 		cmd_set_arg_choice(cmd, arg, *spell);
 		return CMD_OK;
 	}

--- a/src/cmd-core.h
+++ b/src/cmd-core.h
@@ -383,8 +383,9 @@ int cmd_get_string(struct command *cmd, const char *arg, const char **str,
 				   const char *initial, const char *title, const char *prompt);
 int cmd_get_spell(struct command *cmd, const char *arg, struct player *p,
 	int *spell, const char *verb, item_tester book_filter,
-	const char *error,
-	bool (*spell_filter)(const struct player *p, int spell));
+	const char *book_error,
+	bool (*spell_filter)(const struct player *p, int spell),
+	const char *spell_error);
 int cmd_get_effect_from_list(struct command *cmd, const char *arg, int *choice,
 	const char *prompt, struct effect *effect, int count,
 	bool allow_random);

--- a/src/game-input.c
+++ b/src/game-input.c
@@ -32,8 +32,9 @@ int (*get_spell_from_book_hook)(struct player *p, const char *verb,
 	struct object *book, const char *error,
 	bool (*spell_filter)(const struct player *p, int spell));
 int (*get_spell_hook)(struct player *p, const char *verb,
-	item_tester book_filter, cmd_code cmd, const char *error,
-	bool (*spell_filter)(const struct player *p, int spell));
+	item_tester book_filter, cmd_code cmd, const char *book_error,
+	bool (*spell_filter)(const struct player *p, int spell),
+	const char *spell_error, struct object **rtn_book);
 bool (*get_item_hook)(struct object **choice, const char *pmt, const char *str,
 					  cmd_code cmd, item_tester tester, int mode);
 int (*get_effect_from_list_hook)(const char* prompt,
@@ -163,15 +164,32 @@ int get_spell_from_book(struct player *p, const char *verb,
 
 /**
  * Get a spell from the player.
+ *
+ * \param p is the player.
+ * \param verb is the string describing the action for which the spell is
+ * requested.  It is typically "cast" or "study".
+ * \param book_filter is the function (if any) to test that an object is
+ * appropriate for use as spellbook by the player.
+ * \param cmd is the command (if any) the request is called from.
+ * \param book_error is the message to display if no valid book is available.
+ * If NULL, no message will be displayed.
+ * \param spell_filter is the function to call to test if a spell is a valid
+ * selection for the request.
+ * \param spell_error is the message to display if no valid spell is available.
+ * If NULL, no message will be displayed.
+ * \param rtn_book if not NULL, is dereferenced and set to the book selected.
+ * \return the index of the spell selected or a negative value if the selection
+ * failed for any reason.
  */
 int get_spell(struct player *p, const char *verb,
-		item_tester book_filter, cmd_code cmd, const char *error,
-		bool (*spell_filter)(const struct player *p, int spell))
+		item_tester book_filter, cmd_code cmd, const char *book_error,
+		bool (*spell_filter)(const struct player *p, int spell),
+		const char *spell_error, struct object **rtn_book)
 {
 	/* Ask the UI for it */
 	if (get_spell_hook) {
-		return get_spell_hook(p, verb, book_filter, cmd, error,
-			spell_filter);
+		return get_spell_hook(p, verb, book_filter, cmd, book_error,
+			spell_filter, spell_error, rtn_book);
 	}
 	return -1;
 }

--- a/src/game-input.h
+++ b/src/game-input.h
@@ -46,8 +46,9 @@ extern int (*get_spell_from_book_hook)(struct player *p, const char *verb,
 	struct object *book, const char *error,
 	bool (*spell_filter)(const struct player *p, int spell));
 extern int (*get_spell_hook)(struct player *p, const char *verb,
-	item_tester book_filter, cmd_code cmd, const char *error,
-	bool (*spell_filter)(const struct player *p, int spell));
+	item_tester book_filter, cmd_code cmd, const char *book_error,
+	bool (*spell_filter)(const struct player *p, int spell),
+	const char *spell_error, struct object **rtn_book);
 extern bool (*get_item_hook)(struct object **choice, const char *pmt,
 							 const char *str, cmd_code cmd, item_tester tester,
 							 int mode);
@@ -72,8 +73,9 @@ int get_spell_from_book(struct player *p, const char *verb,
 	struct object *book, const char *error,
 	bool (*spell_filter)(const struct player *p, int spell));
 int get_spell(struct player *p, const char *verb,
-	item_tester book_filter, cmd_code cmd, const char *error,
-	bool (*spell_filter)(const struct player *p, int spell));
+	item_tester book_filter, cmd_code cmd, const char *book_error,
+	bool (*spell_filter)(const struct player *p, int spell),
+	const char *spell_error, struct object **rtn_book);
 bool get_item(struct object **choice, const char *pmt, const char *str,
 			  cmd_code cmd, item_tester tester, int mode);
 int get_effect_from_list(const char *prompt, struct effect *effect, int count,


### PR DESCRIPTION
…trieving the book selected, recording it in the command in cmd_get_spell(), and to have a separate error message if the book selected has no spells available. Generalize cmd_disable_repeat_floor_item() to test all command arguments using objects. Resolves https://github.com/angband/angband/issues/5122 .