### PR TITLE
Add hex escape sequence for nds config files (#5394)

### DIFF
--- a/src/nds/nds-buttons.c
+++ b/src/nds/nds-buttons.c
@@ -100,6 +100,7 @@ void nds_btn_add_mappings(const nds_btn_map_entry *new_entries, int num) {
  * The second part of the line is delimited by a ':', followed by a sequence of up to
  * NDS_BTN_SEQ_LEN character inputs that should be triggered.
  * Escaped characters are escaped using '\' (most notably "\r", "\b", "\e", "\t" and "\\").
+ * Arbitrary characters can be encoded in hexadecimal using "\x", in the format "\xa2".
  * Quotation marks and question marks are not escaped and can be used as-is.
  *
  * Encoding a null-byte will end the input sequence, even if more characters may follow.

--- a/src/nds/nds-screenkeys.c
+++ b/src/nds/nds-screenkeys.c
@@ -46,6 +46,7 @@ int nds_scrkeys_num = 0;
  *
  * Escaped characters in the input sequence are escaped using '\'
  * (most notably "\r", "\b", "\e", "\t" and "\\").
+ * Arbitrary characters can be encoded in hexadecimal using "\x", in the format "\xa2".
  * Quotation marks and question marks are not escaped and can be used as-is.
  *
  * Encoding a null-byte will end the input sequence, even if more characters may follow.

--- a/src/tests/z-util/util.c
+++ b/src/tests/z-util/util.c
@@ -215,11 +215,35 @@ static int test_utf32_to_utf8(void *state) {
 	ok;
 }
 
+static int test_hex_str_to_int(void *state) {
+	require(hex_str_to_int("1Ba0") == 0x1ba0);
+	require(hex_str_to_int("5z2") == -1);
+	ok;
+}
+
+static int test_strunescape(void *state) {
+	char x_empty[] = "\\x";
+	strunescape(x_empty);
+	require(!strcmp(x_empty, "\\x"));
+	char x_single[] = "\\xa";
+	strunescape(x_single);
+	require(!strcmp(x_single, "\\xa"));
+	char x_test[] = "\\xaD";
+	strunescape(x_test);
+	require(!strcmp(x_test, "\xaD"));
+	char full_test[] = "\\\\test\\z\\xa0\\n4\\xFd";
+	strunescape(full_test);
+	require(!strcmp(full_test, "\\test\\z\xa0\n4\xfd"));
+	ok;
+}
+
 const char *suite_name = "z-util/util";
 struct test tests[] = {
 	{ "utf8_clipto", test_alloc },
 	{ "utf8_fskip", test_utf8_fskip },
 	{ "utf8_rskip", test_utf8_rskip },
 	{ "utf32_to_utf8", test_utf32_to_utf8 },
+	{ "hex_str_to_int", test_hex_str_to_int },
+	{ "strunescape", test_strunescape },
 	{ NULL, NULL }
 };

--- a/src/z-util.c
+++ b/src/z-util.c
@@ -641,9 +641,41 @@ void strescape(char *s, const char c) {
 }
 
 /**
+ * Gives the integer value of a hexadecimal character
+ * Returns -1 if invalid
+ */
+static int hex_char_to_int(char c) {
+	if ((c >= '0') && (c <= '9'))
+		return c - '0';
+	if ((c >= 'A') && (c <= 'F'))
+		return c - 'A' + 10;
+	if ((c >= 'a') && (c <= 'f'))
+		return c - 'a' + 10;
+	return -1;
+}
+
+/**
+ * Gives the integer value of a hexadecimal string
+ * hex_str_to_int("4A") returns 74 == 0x4A
+ * Returns -1 if invalid
+ */
+int hex_str_to_int(const char *s) {
+	int result = 0;
+	while (*s) {
+		int current = hex_char_to_int(*s);
+		if (current == -1)
+			return -1;
+		result *= 16;
+		result += current;
+		++s;
+	}
+	return result;
+}
+
+/**
  * Rewrite string s in-place, replacing encoded representations of escaped characters
  * ("\\r", etc.) with their literal character counterparts.
- * This does only handle escape sequences visible on the ascii manpage (and "\e").
+ * This does only handle escape sequences visible on the ascii manpage (and "\e" and "\x").
  */
 void strunescape(char *s) {
 	char *in = s;
@@ -685,6 +717,35 @@ void strunescape(char *s) {
 			case 'e':
 				*out++ = '\x1B';
 				break;
+			case 'x': {
+				char hex[3];
+				if (*++in == 0) {
+					/* Add back the unmodified sequence */
+					*out++ = '\\';
+					*out++ = 'x';
+					continue;
+				}
+				hex[0] = *in;
+				if (*++in == 0) {
+					/* Add back the unmodified sequence */
+					*out++ = '\\';
+					*out++ = 'x';
+					*out++ = hex[0];
+					continue;
+				}
+				hex[1] = *in;
+				hex[2] = 0;
+				int result = hex_str_to_int(hex);
+				if (result == -1) {
+					/* Add back the unmodified sequence */
+					*out++ = '\\';
+					*out++ = 'x';
+					*out++ = hex[0];
+					*out++ = hex[1];
+				}
+				*out++ = result;
+				break;
+				}
 			default:
 				/* Add back the unmodified sequence */
 				*out++ = '\\';

--- a/src/z-util.h
+++ b/src/z-util.h
@@ -157,6 +157,11 @@ extern void strskip(char *s, const char c, const char e);
 extern void strescape(char *s, const char c);
 
 /**
+ * Get the integer value of a hex string
+ */
+extern int hex_str_to_int(const char *s);
+
+/**
  * Change escaped characters into their literal representation
  */
 extern void strunescape(char *s);


### PR DESCRIPTION
* Add hex escape sequence for nds config files

Add an extra escape sequence, "\x", that can be used in "button-mappings.txt" and "screen-keys.txt" to encode arbitrary characters in the nds and 3ds port.

* Fix missing prototype warning