### PR TITLE
Avoid use of the cave global when there's a struct chunk function par…

### DIFF
--- a/src/obj-pile.c
+++ b/src/obj-pile.c
@@ -871,7 +871,7 @@ static void floor_carry_fail(struct chunk *c, struct object *drop, bool broke)
 		msg("The %s %s.", o_name, verb);
 	}
 	delist_object(c, drop);
-	object_delete(cave, &drop);
+	object_delete(c, &drop);
 }
 
 /**


### PR DESCRIPTION
…ameter that's appropriate. Related to https://github.com/angband/angband/issues/4934 .