### PR TITLE
Fix so an invalid monster spell name for the message-vis, message-inv…

### DIFF
--- a/src/mon-init.c
+++ b/src/mon-init.c
@@ -748,7 +748,7 @@ static enum parser_error parse_mon_spell_name(struct parser *p) {
 	const char *name = parser_getstr(p, "name");
 	int index;
 	s->next = h;
-	if (grab_name("monster spell", name, r_info_spell_flags, N_ELEMENTS(r_info_spell_flags), &index))
+	if (grab_name("monster spell", name, r_info_spell_flags, N_ELEMENTS(r_info_spell_flags) - 1, &index))
 		return PARSE_ERROR_INVALID_SPELL_NAME;
 	s->index = index;
 	s->max_range = z_info->max_range;
@@ -1746,7 +1746,7 @@ static enum parser_error parse_monster_msg_vis(struct parser *p) {
 
 	if (!r) return PARSE_ERROR_MISSING_RECORD_HEADER;
 	if (grab_name("monster spell", spell, r_info_spell_flags,
-			N_ELEMENTS(r_info_spell_flags), &s_idx))
+			N_ELEMENTS(r_info_spell_flags) - 1, &s_idx))
 			return PARSE_ERROR_INVALID_SPELL_NAME;
 	add_alternate_spell_message(r, s_idx, MON_ALTMSG_SEEN, msg);
 
@@ -1762,7 +1762,7 @@ static enum parser_error parse_monster_msg_invis(struct parser *p) {
 
 	if (!r) return PARSE_ERROR_MISSING_RECORD_HEADER;
 	if (grab_name("monster spell", spell, r_info_spell_flags,
-			N_ELEMENTS(r_info_spell_flags), &s_idx))
+			N_ELEMENTS(r_info_spell_flags) - 1, &s_idx))
 			return PARSE_ERROR_INVALID_SPELL_NAME;
 	add_alternate_spell_message(r, s_idx, MON_ALTMSG_UNSEEN, msg);
 

--- a/src/tests/parse/r-info.c
+++ b/src/tests/parse/r-info.c
@@ -350,6 +350,14 @@ static int test_messagevis0(void *state) {
 	ok;
 }
 
+static int test_messagevis_bad0(void *state) {
+	enum parser_error r = parser_parse(state,
+		"message-vis:XYZZY:{name} waves its tentacles menacingly.");
+
+	eq(r, PARSE_ERROR_INVALID_SPELL_NAME);
+	ok;
+}
+
 static int test_messageinvis0(void *state) {
 	enum parser_error r = parser_parse(state,
 		"message-invis:ARROW1");
@@ -359,6 +367,14 @@ static int test_messageinvis0(void *state) {
 	mr = parser_priv(state);
 	require(mr);
 	require(has_alternate_message(mr, RSF_ARROW1, MON_ALTMSG_UNSEEN, ""));
+	ok;
+}
+
+static int test_messageinvis_bad0(void *state) {
+	enum parser_error r = parser_parse(state,
+		"message-invis:XYZZY:Something whispers.");
+
+	eq(r, PARSE_ERROR_INVALID_SPELL_NAME);
 	ok;
 }
 
@@ -385,6 +401,8 @@ struct test tests[] = {
 	{ "spell-power0", test_spell_power0 },
 	{ "spells0", test_spells0 },
 	{ "message-vis0", test_messagevis0 },
+	{ "message-vis-bad0", test_messagevis_bad0 },
 	{ "message-invis0", test_messageinvis0 },
+	{ "message-invis-bad0", test_messageinvis_bad0 },
 	{ NULL, NULL }
 };


### PR DESCRIPTION
…is, and message-miss directives in monster.txt or the name directive in monster_spell.txt does not cause a null pointer to be dereferenced in grab_name(). Add test cases to exercise that for monster.txt.