### PR TITLE
Merge in buildsys's upstream changes as of 2021/12/5. Subdirectory …

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -88,6 +88,7 @@ fi
 # Prefer cc to gcc (default behavior is the opposite) for better compatibility
 # with OpenBSD and FreeBSD.
 AC_PROG_CC([cc gcc clang])
+AC_PROG_CPP
 AC_PROG_MAKE_SET
 AC_PROG_LN_S
 AC_PROG_INSTALL


### PR DESCRIPTION
…handling is still the old style (using the one that's current in buildsys causes "make" at the top-level to do nothing in the src directory presumably because SUBDIRS and SUBDIRS_AFTER are empty there leaving a target with nothing to the left of the ':').