### PR TITLE
Port over Vanilla Angband's UN_KTRL_CAP

### DIFF
--- a/src/ui-event.h
+++ b/src/ui-event.h
@@ -124,6 +124,14 @@ typedef enum
 
 
 /**
+ * Given a control character X, turn it into its uppercase ASCII equivalent.
+ * Prefer using UN_KTRL() over this except for inscription testing and menu
+ * shortcuts where there are clashes.
+ */
+#define UN_KTRL_CAP(X) \
+	((X) + 64)
+
+/**
  * Keyset mappings for various keys.
  */
 #define ARROW_DOWN    0x80


### PR DESCRIPTION
Do not currently use it since do not have clashes for inscriptions or context menu shortcuts.  There are some overlaps when control is stripped (fuel a light source, ^f, with the fire commands, f and F; forge an item in the Angband-like keyset with Rogue-like navigation, ^d, and drop, d).  Those do not appear in the same context menus, and there's no useful object inscriptions targeting both of the commands involved in an overlap.