### PR TITLE
Small optimization for lookup_sval(): skip name formatting and string…

### DIFF
--- a/src/obj-util.c
+++ b/src/obj-util.c
@@ -433,14 +433,13 @@ int lookup_sval(int tval, const char *name)
 		struct object_kind *kind = &k_info[k];
 		char cmp_name[1024];
 
-		if (!kind || !kind->name) continue;
+		if (!kind || !kind->name || kind->tval != tval) continue;
 
 		obj_desc_name_format(cmp_name, sizeof cmp_name, 0, kind->name, 0,
 							 false);
 
 		/* Found a match */
-		if (kind->tval == tval && !my_stricmp(cmp_name, name))
-			return kind->sval;
+		if (!my_stricmp(cmp_name, name)) return kind->sval;
 	}
 
 	return -1;


### PR DESCRIPTION
… comparison when tval doesn't match. With the optimization (on Mac OS X, compiled with "-O2 -DNDEBUG -DUSE_STATS"), lookup_sval() took up 2.2% (10 milliseconds out of 455 milliseconds) of the time for place_object() in Instruments' Time Profiler sampling of the place_object() calls made for classic_gen() when generating 10000 levels for disconnection statistics. Without the optimization, it took up 8.5% (42 milliseconds out of 495 milliseconds) of the time for place_object() in the same conditions.