### PR TITLE
Use angle brackets rather than double quotes for including locale.h a…

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -35,10 +35,10 @@
 /**
  * locale junk
  */
-#include "locale.h"
+#include <locale.h>
 
 #if !defined(WINDOWS)
-#include "langinfo.h"
+#include <langinfo.h>
 #endif
 
 /**


### PR DESCRIPTION
…nd langinfo.h: matches the usage in the Mac OS X and Debian man pages for setlocale() and nl_langinfo().