### PR TITLE
Tighten parsing in z-expression.c so "++" and "**" aren't synonyms …

### DIFF
--- a/src/z-expression.c
+++ b/src/z-expression.c
@@ -87,21 +87,31 @@ typedef enum expression_input_e {
  */
 static expression_operator_t expression_operator_from_token(const char *token)
 {
+	expression_operator_t result;
+
 	switch (token[0]) {
 		case '+':
-			return OPERATOR_ADD;
+			result = OPERATOR_ADD;
+			break;
 		case '-':
-			return OPERATOR_SUB;
+			result = OPERATOR_SUB;
+			break;
 		case '*':
-			return OPERATOR_MUL;
+			result = OPERATOR_MUL;
+			break;
 		case '/':
-			return OPERATOR_DIV;
+			result = OPERATOR_DIV;
+			break;
 		case 'n':
 		case 'N':
-			return OPERATOR_NEG;
+			result = OPERATOR_NEG;
+			break;
+		default:
+			return OPERATOR_NONE;
 	}
 
-	return OPERATOR_NONE;
+	/* Reject if there's additional junk in the token after the operator. */
+	return (token[1]) ? OPERATOR_NONE : result;
 }
 
 /**


### PR DESCRIPTION
…for "+" and "*", respectively.