### PR TITLE
Adjust handling of cuts and poisoning

### DIFF
--- a/lib/gamedata/player_timed.txt
+++ b/lib/gamedata/player_timed.txt
@@ -114,8 +114,8 @@ fail:PROT_HALLU
 
 name:POISONED
 desc:poisoning
-change-grade:g:20:Poisoned
-change-grade:G:100:Poisoned
+change-grade:g:20:3:Poisoned
+change-grade:G:100:3:Poisoned
 change-inc:10:You have been poisoned.:You have been further poisoned.
 change-inc:20:You have been badly poisoned.
 change-inc:100:You have been severely poisoned.
@@ -125,8 +125,9 @@ msgt:POISONED
 
 name:CUT
 desc:wounds
-change-grade:R:20:Bleeding
-change-grade:r:100:Bleeding
+change-grade:R:20:2:Bleeding
+change-grade:r:99:2:Bleeding
+change-grade:r:100:0:Mortal wound
 change-inc:10:You have been given a cut.
 change-inc:20:You have been given a deep cut.
 change-inc:100:You have been given a severe cut.

--- a/src/player-timed.c
+++ b/src/player-timed.c
@@ -286,9 +286,21 @@ static enum parser_error parse_player_timed_change_grade(struct parser *p)
 	struct timed_effect_data *t = parser_priv(p);
 	struct timed_change_grade *current = t->c_grade;
 	struct timed_change_grade *l = mem_zalloc(sizeof(*l));
-    const char *color = parser_getsym(p, "color");
-    int attr = 0;
+	const char *color = parser_getsym(p, "color");
+	int grade_max = parser_getint(p, "max");
+	int attr;
+
 	assert(t);
+
+	/*
+	 * The maximum should be greater than zero so it does not interfere
+	 * with the implicit "off" grade.  Because the player's timed array
+	 * has int16_t elements, ensure that the maximum is compatible with
+	 * that.
+	 */
+	if (grade_max <= 0 || grade_max > 32767) {
+		return PARSE_ERROR_INVALID_VALUE;
+	}
 
 	/* Make a zero grade structure if there isn't one */
 	if (!current) {
@@ -305,16 +317,18 @@ static enum parser_error parse_player_timed_change_grade(struct parser *p)
 	current->next = l;
 	l->c_grade = current->c_grade + 1;
 
-    if (strlen(color) > 1) {
+	if (strlen(color) > 1) {
 		attr = color_text_to_attr(color);
-    } else {
+	} else {
 		attr = color_char_to_attr(color[0]);
 	}
-    if (attr < 0)
+	if (attr < 0) {
 		return PARSE_ERROR_INVALID_COLOR;
-    l->color = attr;
+	}
+	l->color = attr;
 
-	l->max = parser_getint(p, "max");
+	l->max = grade_max;
+	l->digits = parser_getint(p, "digits");
 	l->name = string_make(parser_getsym(p, "name"));
 
 	/* Name may be a dummy (eg hunger)*/
@@ -373,7 +387,7 @@ static struct parser *init_parse_player_timed(void)
 	parser_reg(p, "fail str flag", parse_player_timed_fail);
 	parser_reg(p, "grade sym color int max sym name sym up_msg ?sym down_msg",
 			   parse_player_timed_grade);
-	parser_reg(p, "change-grade sym color int max sym name",
+	parser_reg(p, "change-grade sym color int max int digits sym name",
 			   parse_player_timed_change_grade);
 	parser_reg(p, "resist sym elem", parse_player_timed_resist);
 	parser_reg(p, "este uint value", parse_player_timed_este);
@@ -702,10 +716,24 @@ bool player_set_timed(struct player *p, int idx, int v, bool notify,
 			}
 		}
 	} else {
+		const struct timed_change_grade *last_grade = effect->c_grade;
 		int change;
 
 		/* There had better be a change grade */
-		assert(effect->c_grade);
+		assert(last_grade);
+
+		/* Upper bound is the maximum for the last change grade */
+		while (last_grade->next) last_grade = last_grade->next;
+		if (v > last_grade->max) {
+			if (p->timed[idx] == last_grade->max) {
+				/*
+				 * No change:  tried to exceed the maximum
+				 * possible but already at that maximum
+				 */
+				return false;
+			}
+			v = last_grade->max;
+		}
 
 		/* Find the change we will be using */
 		change = v - p->timed[idx];
@@ -713,25 +741,30 @@ bool player_set_timed(struct player *p, int idx, int v, bool notify,
 		/* Increase */
 		if (change > 0) {
 			struct timed_change *inc = effect->increase;
-			while (change >= inc->max) {
+			while (change >= inc->max && inc->next) {
 				inc = inc->next;
 			}
 			if (p->timed[idx] && inc->inc_msg) {
 				/* Increasing from existing effect, and increase message */
 				msgt(effect->msgt, inc->inc_msg);
+				notify = true;
 			} else {
 				/* Effect starting, or no special increase message */
 				msgt(effect->msgt, inc->msg);
+				notify = true;
 			}
 		} else {
 			/* Decrease */
-			int div = effect->decrease.max;
-			if (-change > (p->timed[idx] + div - 1) / div) {
-				msgt(effect->msgt, effect->decrease.msg);
-			}
-			/* Finishing */
 			if (v == 0) {
+				/* Finishing */
 				msgt(effect->msgt, effect->on_end);
+				notify = true;
+			} else {
+				int div = effect->decrease.max;
+				if (-change > (p->timed[idx] + div - 1) / div) {
+					msgt(effect->msgt, effect->decrease.msg);
+					notify = true;
+				}
 			}
 		}
 	}

--- a/src/player-timed.h
+++ b/src/player-timed.h
@@ -54,6 +54,7 @@ struct timed_change_grade {
 	int c_grade;
 	uint8_t color;
 	int max;
+	int digits;
 	char *name;
 	struct timed_change_grade *next;
 };

--- a/src/ui-display.c
+++ b/src/ui-display.c
@@ -964,18 +964,38 @@ static size_t prt_tmd(int row, int col)
 
 	for (i = 0; i < TMD_MAX; i++) {
 		if (player->timed[i]) {
-			struct timed_grade *grade = timed_effects[i].grade;
-			if (!grade) continue;
-			while (player->timed[i] > grade->max) {
-				grade = grade->next;
-			}
-			if (!grade->name) continue;
-			c_put_str(grade->color, grade->name, row, col + len);
-			len += strlen(grade->name) + 1;
-			if (timed_effects[i].c_grade) {
-				char *meter = format(" %-3d", player->timed[i]);
-				c_put_str(grade->color, meter, row, col + len);
-				len += strlen(meter) + 1;
+			if (timed_effects[i].grade) {
+				const struct timed_grade *grade =
+					timed_effects[i].grade;
+
+				while (player->timed[i] > grade->max) {
+					grade = grade->next;
+				}
+				if (!grade->name) continue;
+				c_put_str(grade->color, grade->name, row,
+					col + len);
+				len += strlen(grade->name) + 1;
+			} else if (timed_effects[i].c_grade) {
+				const struct timed_change_grade *cg =
+					timed_effects[i].c_grade;
+
+				while (player->timed[i] > cg->max && cg->next) {
+					cg = cg->next;
+				}
+				if (!cg->name) continue;
+				if (cg->digits > 0) {
+					char *meter = format("%s %-*d",
+						cg->name, cg->digits,
+						player->timed[i]);
+
+					c_put_str(cg->color, meter, row,
+						col + len);
+					len += strlen(meter) + 1;
+				} else {
+					c_put_str(cg->color, cg->name, row,
+						col + len);
+					len += strlen(cg->name) + 1;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Resolves https://github.com/NickMcConnell/NarSil/issues/547 .

In player_timed.txt, add a parameter to the change-grade directive to set the number of digits to use when formatting the current value of the timed effect.  If that number of digits is less than or equal to zero, only show the name without the current value for the timed effect.  Add a "Mortal wound" level for cuts:  Sil 1.3 and Sil-Q have it though it never is displayed (only triggers when the cut meter is greater than 100 but the cut meter is limited to 0 to 100).  That seems to be a bug in Sil 1.3 and Sil-Q so display the "Mortal wound" level when the cut meter is 100 or more.

In player_set_timed():
	Cap the timed effect's value at the maximum for the effect's last change-grade.  That matches Sil 1.3's behavior where both cuts and poisoning are limited to 100 (see set_cut() and set_poison() in its xtra2.c).
	Do not allow stepping past the last of the messages set by change-inc when choosing which message to display for an increase.
	Notify (and disturb if can_disturb is true) if a message is printed.  That matches up better with what Sil 1.3 does (see set_cut() and set_poison() in its xtra2.c).
	When decreasing, only display the on-end message or the decrease message.  Never display both.  That matches the messaging in set_cut() and set_poison() from Sil 1.3's xtra2.c

On the status line, display the indicator for the timed effect as configured by the change-grade directive.