### PR TITLE
Port Vanilla Angband's change to the debugging command for placing a trap

### DIFF
--- a/src/cmd-wizard.c
+++ b/src/cmd-wizard.c
@@ -848,10 +848,8 @@ void do_cmd_wiz_create_trap(struct command *cmd)
 		cmd_set_arg_number(cmd, "index", tidx);
 	}
 
-	if (!square_isfloor(cave, player->grid)) {
+	if (!square_player_trap_allowed(cave, player->grid)) {
 		msg("You can't place a trap there!");
-	} else if (player->depth == 0) {
-		msg("You can't place a trap in the town!");
 	} else if (tidx < 1 || tidx >= z_info->trap_max) {
 		msg("Trap not found.");
 	} else {


### PR DESCRIPTION
Uses the same prequisites as are used elsewhere for adding a trap to a grid.  Also drop the restriction of no traps at a depth of zero since that is not relevant for NarSil.