### PR TITLE
Windows: have the enabled status of the 16 x 16 tile multiplier menu …

### DIFF
--- a/src/main-win.c
+++ b/src/main-win.c
@@ -3053,7 +3053,7 @@ static void setup_menus(void)
 	EnableMenuItem(hm, IDM_OPTIONS_GRAPHICS_NICE,
 				   MF_BYCOMMAND | MF_DISABLED | MF_GRAYED);
 
-	for (i = IDM_OPTIONS_TILE_1x1; i < IDM_OPTIONS_TILE_16x16; i++) {
+	for (i = IDM_OPTIONS_TILE_1x1; i <= IDM_OPTIONS_TILE_16x16; i++) {
 		EnableMenuItem(hm, i, MF_BYCOMMAND | MF_DISABLED | MF_GRAYED);
 	}
 	for (i = IDM_TILE_FONT; i < IDM_TILE_12X13; i++) {
@@ -3186,8 +3186,12 @@ static void setup_menus(void)
 
 		EnableMenuItem(hm, IDM_OPTIONS_GRAPHICS_NICE, MF_ENABLED);
 
-		for (i = IDM_OPTIONS_TILE_1x1; i < IDM_OPTIONS_TILE_16x16; i++) {
-			EnableMenuItem(hm, i, MF_ENABLED);
+		/* Only enable the multiplier entries if using a tile set. */
+		if (current_graphics_mode && current_graphics_mode->grafID) {
+			for (i = IDM_OPTIONS_TILE_1x1;
+					i <= IDM_OPTIONS_TILE_16x16; i++) {
+				EnableMenuItem(hm, i, MF_ENABLED);
+			}
 		}
 		for (i = IDM_TILE_FONT; i < IDM_TILE_12X13; i++) {
 			EnableMenuItem(hm, i, MF_ENABLED);


### PR DESCRIPTION
…entry act like the other multiplier entries (pointed out in https://github.com/angband/angband/issues/5552 ) ; disable all the tile multiplier entries when not using tiles