### PR TITLE
prt_terrain(): use size of destination buffer rather than source buff…

### DIFF
--- a/src/ui-display.c
+++ b/src/ui-display.c
@@ -966,16 +966,17 @@ static size_t prt_terrain(int row, int col)
 	struct feature *feat = square_feat(cave, player->grid);
 	struct trap *trap = square_trap(cave, player->grid);
 	char buf[30];
+	uint8_t attr;
 
 	if (trap && !square_isinvis(cave, player->grid)) {
-		my_strcpy(buf, trap->kind->name, strlen(trap->kind->name) + 1);
-		my_strcap(buf);
-		c_put_str(trap->kind->d_attr, format("%s ", buf), row, col);
+		my_strcpy(buf, trap->kind->name, sizeof(buf));
+		attr = trap->kind->d_attr;
 	} else {
-		my_strcpy(buf, feat->name, strlen(feat->name) + 1);
-		my_strcap(buf);
-		c_put_str(feat->d_attr, format("%s ", buf), row, col);
+		my_strcpy(buf, feat->name, sizeof(buf));
+		attr = feat->d_attr;
 	}
+	my_strcap(buf);
+	c_put_str(attr, format("%s ", buf), row, col);
 
 	return longest_terrain_name() + 1;
 }


### PR DESCRIPTION
…er as the argument to my_strcpy(). No known ill effects with Vanilla (all traps and terrain have names that are shorter than 30 characters). Move some common code out of the if/else.