### PR TITLE
macOS: coerce width and height of big cursor to avoid possibility of …

### DIFF
--- a/src/main-cocoa.m
+++ b/src/main-cocoa.m
@@ -4483,11 +4483,14 @@ static errr Term_curs_cocoa(int x, int y)
 static errr Term_bigcurs_cocoa(int x, int y)
 {
     AngbandContext *angbandContext = (__bridge AngbandContext*) (Term->data);
+    /* Out of paranoia, coerce to remain in bounds. */
+    int w = (x + tile_width <= angbandContext.cols) ?
+        tile_width : angbandContext.cols - x;
+    int h = (y + tile_height <= angbandContext.rows) ?
+        tile_height : angbandContext.rows - y;
 
-    [angbandContext.contents setCursorAtColumn:x row:y width:tile_width
-		   height:tile_height];
-    [angbandContext.changes markChangedBlockAtColumn:x row:y width:tile_width
-		   height:tile_height];
+    [angbandContext.contents setCursorAtColumn:x row:y width:w height:h];
+    [angbandContext.changes markChangedBlockAtColumn:x row:y width:w height:h];
 
     /* Success */
     return 0;


### PR DESCRIPTION
…out-of-bounds array accesses