### PR TITLE
Port Vanilla Angband's changes for more test coverage of init.c and trap.c

### DIFF
--- a/lib/gamedata/constants.txt
+++ b/lib/gamedata/constants.txt
@@ -17,27 +17,12 @@ level-max:monsters:300
 # 1/per-turn-chance of new monster generation
 mon-gen:chance:160
 
-# Minimum number of monsters generated on a level
-mon-gen:level-min:14
-
-# Maximum number of breeding monsters allowed on a level
-mon-gen:repro-max:100
-
-# Maximum out-of-depth amount for monster generation
-mon-gen:ood-amount:10
-
 # Maximum number of monsters in a group
 mon-gen:group-max:25
-
-# Maximum distance of a group of monsters from a related group
-mon-gen:group-dist:5
 
 #---------------------------------------------------------------------
 # Monster Gameplay
 #---------------------------------------------------------------------
-
-# Rune of protection resistance to monster breaking
-mon-play:break-glyph:550
 
 # High value slows multiplication
 mon-play:mult-rate:8
@@ -114,15 +99,6 @@ world:flow-max:250
 
 # Max number of pack slots for carrying inventory
 carry-cap:pack-size:23
-
-# Max number of quiver slots for carrying missiles
-carry-cap:quiver-size:10
-
-# Max number of missiles per quiver slot
-carry-cap:quiver-slot-size:40
-
-# For computing quiver capacity, is the multiplier for non-ammo thrown items
-carry-cap:thrown-quiver-mult:5
 
 # Maximum number of objects allowed in a single dungeon grid.
 #

--- a/src/cmd-wizard.c
+++ b/src/cmd-wizard.c
@@ -507,12 +507,6 @@ void do_cmd_wiz_change_item_quantity(struct command *cmd)
 		/* Items with charges have a limit imposed by MAX_PVAL. */
 		nmax = MIN((MAX_PVAL * obj->number) / obj->pval, nmax);
 	}
-	if (object_is_in_quiver(player, obj)) {
-		/* The quiver may have stricter limits. */
-		nmax = MIN(z_info->quiver_slot_size /
-			(tval_is_ammo(obj) ? 1 : z_info->thrown_quiver_mult),
-			nmax);
-	}
 
 	/* Get the new quantity. */
 	if (cmd_get_arg_number(cmd, "quantity", &n) != CMD_OK) {

--- a/src/init.c
+++ b/src/init.c
@@ -364,22 +364,8 @@ static enum parser_error parse_constants_mon_gen(struct parser *p) {
 
 	if (streq(label, "chance"))
 		z->alloc_monster_chance = value;
-	else if (streq(label, "level-min"))
-		z->level_monster_min = value;
-	else if (streq(label, "town-day"))
-		z->town_monsters_day = value;
-	else if (streq(label, "town-night"))
-		z->town_monsters_night = value;
-	else if (streq(label, "repro-max"))
-		z->repro_monster_max = value;
-	else if (streq(label, "ood-chance"))
-		z->ood_monster_chance = value;
-	else if (streq(label, "ood-amount"))
-		z->ood_monster_amount = value;
 	else if (streq(label, "group-max"))
 		z->monster_group_max = value;
-	else if (streq(label, "group-dist"))
-		z->monster_group_dist = value;
 	else
 		return PARSE_ERROR_UNDEFINED_DIRECTIVE;
 
@@ -398,9 +384,7 @@ static enum parser_error parse_constants_mon_play(struct parser *p) {
 	if (value < 0)
 		return PARSE_ERROR_INVALID_VALUE;
 
-	if (streq(label, "break-glyph"))
-		z->glyph_hardness = value;
-	else if (streq(label, "mult-rate"))
+	if (streq(label, "mult-rate"))
 		z->repro_monster_rate = value;
 	else if (streq(label, "mana-cost"))
 		z->mana_cost = value;
@@ -496,12 +480,6 @@ static enum parser_error parse_constants_carry_cap(struct parser *p) {
 
 	if (streq(label, "pack-size"))
 		z->pack_size = value;
-	else if (streq(label, "quiver-size"))
-		z->quiver_size = value;
-	else if (streq(label, "quiver-slot-size"))
-		z->quiver_slot_size = value;
-	else if (streq(label, "thrown-quiver-mult"))
-		z->thrown_quiver_mult = value;
 	else if (streq(label, "floor-size"))
 		z->floor_size = value;
 	else
@@ -574,7 +552,7 @@ static enum parser_error parse_constants_player(struct parser *p) {
 	return PARSE_ERROR_NONE;
 }
 
-struct parser *init_parse_constants(void) {
+static struct parser *init_parse_constants(void) {
 	struct angband_constants *z = mem_zalloc(sizeof *z);
 	struct parser *p = parser_new();
 
@@ -605,7 +583,7 @@ static void cleanup_constants(void)
 	mem_free(z_info);
 }
 
-static struct file_parser constants_parser = {
+struct file_parser constants_parser = {
 	"constants",
 	init_parse_constants,
 	run_parse_constants,
@@ -716,7 +694,7 @@ static void cleanup_world(void)
 	}
 }
 
-static struct file_parser world_parser = {
+struct file_parser world_parser = {
 	"world",
 	init_parse_world,
 	run_parse_world,
@@ -928,7 +906,7 @@ static enum parser_error parse_feat_look_in_preposition(struct parser *p) {
 	return PARSE_ERROR_NONE;
 }
 
-struct parser *init_parse_feat(void) {
+static struct parser *init_parse_feat(void) {
 	struct parser *p = parser_new();
 	parser_setpriv(p, NULL);
 	parser_reg(p, "name str name", parse_feat_name);
@@ -1019,7 +997,7 @@ static void cleanup_feat(void) {
 	mem_free(f_info);
 }
 
-static struct file_parser feat_parser = {
+struct file_parser feat_parser = {
 	"terrain",
 	init_parse_feat,
 	run_parse_feat,
@@ -1147,7 +1125,7 @@ static void cleanup_body(void)
 	}
 }
 
-static struct file_parser body_parser = {
+struct file_parser body_parser = {
 	"body",
 	init_parse_body,
 	run_parse_body,
@@ -1201,7 +1179,7 @@ static enum parser_error parse_history_phrase(struct parser *p) {
 	return PARSE_ERROR_NONE;
 }
 
-struct parser *init_parse_history(void) {
+static struct parser *init_parse_history(void) {
 	struct parser *p = parser_new();
 	parser_setpriv(p, NULL);
 	parser_reg(p, "chart uint chart int next int roll", parse_history_chart);
@@ -1267,7 +1245,7 @@ static void cleanup_history(void)
 	}
 }
 
-static struct file_parser history_parser = {
+struct file_parser history_parser = {
 	"history",
 	init_parse_history,
 	run_parse_history,
@@ -1294,6 +1272,7 @@ static enum parser_error parse_sex_possess(struct parser *p) {
 	struct player_sex *s = parser_priv(p);
 	if (!s)
 		return PARSE_ERROR_MISSING_RECORD_HEADER;
+	string_free((char*)s->possessive);
 	s->possessive = string_make(parser_getstr(p, "pronoun"));
 	return PARSE_ERROR_NONE;
 }
@@ -1302,11 +1281,12 @@ static enum parser_error parse_sex_poetry(struct parser *p) {
 	struct player_sex *s = parser_priv(p);
 	if (!s)
 		return PARSE_ERROR_MISSING_RECORD_HEADER;
+	string_free((char*)s->poetry_name);
 	s->poetry_name = string_make(parser_getstr(p, "name"));
 	return PARSE_ERROR_NONE;
 }
 
-struct parser *init_parse_sex(void) {
+static struct parser *init_parse_sex(void) {
 	struct parser *p = parser_new();
 	parser_setpriv(p, NULL);
 	parser_reg(p, "name str name", parse_sex_name);
@@ -1347,7 +1327,7 @@ static void cleanup_sex(void)
 	}
 }
 
-static struct file_parser sex_parser = {
+struct file_parser sex_parser = {
 	"sex",
 	init_parse_sex,
 	run_parse_sex,
@@ -1496,7 +1476,7 @@ static enum parser_error parse_race_desc(struct parser *p) {
 	return PARSE_ERROR_NONE;
 }
 
-struct parser *init_parse_race(void) {
+static struct parser *init_parse_race(void) {
 	struct parser *p = parser_new();
 	parser_setpriv(p, NULL);
 	parser_reg(p, "name str name", parse_race_name);
@@ -1551,7 +1531,7 @@ static void cleanup_race(void)
 	}
 }
 
-static struct file_parser race_parser = {
+struct file_parser race_parser = {
 	"race",
 	init_parse_race,
 	run_parse_race,
@@ -1577,6 +1557,7 @@ static enum parser_error parse_house_name(struct parser *p) {
 static enum parser_error parse_house_alt_name(struct parser *p) {
 	struct player_house *h = parser_priv(p);
 	if (!h) return PARSE_ERROR_MISSING_RECORD_HEADER;
+	string_free((char*)h->alt_name);
 	h->alt_name = string_make(parser_getstr(p, "name"));
 	return PARSE_ERROR_NONE;
 }
@@ -1584,6 +1565,7 @@ static enum parser_error parse_house_alt_name(struct parser *p) {
 static enum parser_error parse_house_short_name(struct parser *p) {
 	struct player_house *h = parser_priv(p);
 	if (!h) return PARSE_ERROR_MISSING_RECORD_HEADER;
+	string_free((char*)h->short_name);
 	h->short_name = string_make(parser_getstr(p, "name"));
 	return PARSE_ERROR_NONE;
 }
@@ -1663,7 +1645,7 @@ static enum parser_error parse_house_desc(struct parser *p) {
 	return PARSE_ERROR_NONE;
 }
 
-struct parser *init_parse_house(void) {
+static struct parser *init_parse_house(void) {
 	struct parser *p = parser_new();
 	parser_setpriv(p, NULL);
 	parser_reg(p, "name str name", parse_house_name);
@@ -1710,7 +1692,7 @@ static void cleanup_house(void)
 	}
 }
 
-static struct file_parser house_parser = {
+struct file_parser house_parser = {
 	"house",
 	init_parse_house,
 	run_parse_house,
@@ -1757,7 +1739,7 @@ static enum parser_error parse_names_word(struct parser *p) {
 	return PARSE_ERROR_NONE;
 }
 
-struct parser *init_parse_names(void) {
+static struct parser *init_parse_names(void) {
 	struct parser *p = parser_new();
 	struct names_parse *n = mem_zalloc(sizeof *n);
 	n->section = 0;
@@ -1870,7 +1852,7 @@ static enum parser_error parse_flavor_kind(struct parser *p) {
 }
 
 
-struct parser *init_parse_flavor(void) {
+static struct parser *init_parse_flavor(void) {
 	struct parser *p = parser_new();
 	parser_setpriv(p, NULL);
 

--- a/src/init.h
+++ b/src/init.h
@@ -61,17 +61,9 @@ struct angband_constants
 
 	/* Monster generation constants, read from constants.txt */
 	uint16_t alloc_monster_chance;	/**< 1/per-turn-chance of generation */
-	uint16_t level_monster_min;	/**< Minimum number generated */
-	uint16_t town_monsters_day;	/**< Townsfolk generated - day */
-	uint16_t town_monsters_night;	/**< Townsfolk generated  - night */
-	uint16_t repro_monster_max;	/**< Maximum breeders on a level */
-	uint16_t ood_monster_chance;	/**< Chance of OoD monster is 1 in this */
-	uint16_t ood_monster_amount;	/**< Max number of levels OoD */
 	uint16_t monster_group_max;	/**< Maximum size of a group */
-	uint16_t monster_group_dist;	/**< Max dist of a group from a related group */
 
 	/* Monster gameplay constants, read from constants.txt */
-	uint16_t glyph_hardness;	/**< How hard for a monster to break a glyph */
 	uint16_t repro_monster_rate;	/**< Monster reproduction rate-slower */
 	uint16_t mana_cost;			/**< Mana it costs a monster to cast a  spell */
 	uint16_t mana_max;			/**< Maximum amount of mana a monster can have*/
@@ -99,9 +91,6 @@ struct angband_constants
 
 	/* Carrying capacity constants, read from constants.txt */
 	uint16_t pack_size;		/**< Maximum number of pack slots */
-	uint16_t quiver_size;		/**< Maximum number of quiver slots */
-	uint16_t quiver_slot_size;	/**< Maximum number of missiles per quiver slot */
-	uint16_t thrown_quiver_mult;	/**< Size multiplier for non-ammo in quiver */
 	uint16_t floor_size;		/**< Maximum number of items per floor grid */
 
 	/* Object creation constants, read from constants.txt */
@@ -153,28 +142,28 @@ extern char *ANGBAND_DIR_SCORES;
 extern char *ANGBAND_DIR_ARCHIVE;
 
 extern struct parser *init_parse_artifact(void);
-extern struct parser *init_parse_race(void);
-extern struct parser *init_parse_house(void);
-extern struct parser *init_parse_sex(void);
 extern struct parser *init_parse_ego(void);
-extern struct parser *init_parse_feat(void);
-extern struct parser *init_parse_history(void);
 extern struct parser *init_parse_object(void);
 extern struct parser *init_parse_object_base(void);
 extern struct parser *init_parse_pain(void);
-extern struct parser *init_parse_p_race(void);
 extern struct parser *init_parse_pit(void);
 extern struct parser *init_parse_monster(void);
 extern struct parser *init_parse_vault(void);
-extern struct parser *init_parse_constants(void);
-extern struct parser *init_parse_flavor(void);
-extern struct parser *init_parse_names(void);
-extern struct parser *init_parse_hints(void);
-extern struct parser *init_parse_trap(void);
 extern struct parser *init_parse_chest_trap(void);
 extern struct parser *init_parse_quest(void);
 
+/* These are public primarily to facilitate writing test cases */
+extern struct file_parser body_parser;
+extern struct file_parser constants_parser;
+extern struct file_parser feat_parser;
 extern struct file_parser flavor_parser;
+extern struct file_parser history_parser;
+extern struct file_parser house_parser;
+extern struct file_parser names_parser;
+extern struct file_parser race_parser;
+extern struct file_parser sex_parser;
+extern struct file_parser trap_parser;
+extern struct file_parser world_parser;
 
 errr grab_effect_data(struct parser *p, struct effect *effect);
 extern void init_file_paths(const char *config, const char *lib, const char *data);

--- a/src/obj-pile.c
+++ b/src/obj-pile.c
@@ -1176,8 +1176,7 @@ int scan_distant_floor(struct object **items, int max_size, struct player *p,
  * Returns the number of items placed into the list.
  *
  * Maximum space that can be used is
- * z_info->pack_size + z_info->quiver_size + player->body.count +
- * z_info->floor_size,
+ * z_info->pack_size + player->body.count + z_info->floor_size,
  * though practically speaking much smaller numbers are likely.
  */
 int scan_items(struct object **item_list, size_t item_max, struct player *p,

--- a/src/player-calcs.c
+++ b/src/player-calcs.c
@@ -322,8 +322,7 @@ int equipped_item_slot(struct player_body body, struct object *item)
 void calc_inventory(struct player *p)//TODO make two quivers (= quiver slots?)
 {
 	int old_inven_cnt = p->upkeep->inven_cnt;
-	int n_max = 1 + z_info->pack_size + z_info->quiver_size
-		+ p->body.count;
+	int n_max = 1 + z_info->pack_size + p->body.count;
 	struct object **old_pack = mem_zalloc(z_info->pack_size
 		* sizeof(*old_pack));
 	bool *assigned = mem_alloc(n_max * sizeof(*assigned));
@@ -332,7 +331,7 @@ void calc_inventory(struct player *p)//TODO make two quivers (= quiver slots?)
 
 	/*
 	 * Equipped items are already taken care of.  Only the others need
-	 * to be tested for assignment to the quiver or pack.
+	 * to be tested for assignment to the pack.
 	 */
 	for (current = p->gear, j = 0; current; current = current->next, ++j) {
 		assert(j < n_max);

--- a/src/tests/parse/body.c
+++ b/src/tests/parse/body.c
@@ -1,0 +1,183 @@
+/* parse/body */
+/* Exercise parsing used for body.txt. */
+
+#include "unit-test.h"
+#include "init.h"
+#include "obj-gear.h"
+#include "z-virt.h"
+
+int setup_tests(void **state) {
+	*state = body_parser.init();
+	/* body_parser.finish() needs z_info. */
+	z_info = mem_zalloc(sizeof(*z_info));
+	return !*state;
+}
+
+int teardown_tests(void *state) {
+	struct parser *p = (struct parser*) state;
+	int r = 0;
+
+	if (body_parser.finish(p)) {
+		r = 1;
+	}
+	body_parser.cleanup();
+	mem_free(z_info);
+	return r;
+}
+
+static int test_missing_record_header0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r;
+
+	null(parser_priv(p));
+	r = parser_parse(p, "slot:WEAPON:weapon");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	ok;
+}
+
+static int test_body0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r = parser_parse(p, "body:Test Body 1");
+	struct player_body *b;
+
+	eq(r, PARSE_ERROR_NONE);
+	b = (struct player_body*) parser_priv(p);
+	notnull(b);
+	notnull(b->name);
+	require(streq(b->name, "Test Body 1"));
+	eq(b->count, 0);
+	null(b->slots);
+	ok;
+}
+
+static int test_slot0(void *state) {
+	struct parser *p = (struct parser*) state;
+	struct player_body *b = (struct player_body*) parser_priv(p);
+	struct equip_slot *s;
+	enum parser_error r;
+	uint16_t old_count;
+
+	notnull(b);
+	old_count = b->count;
+	r = parser_parse(p, "slot:WEAPON:weapon");
+	eq(r, PARSE_ERROR_NONE);
+	b = (struct player_body*) parser_priv(p);
+	notnull(b);
+	eq(b->count, old_count + 1);
+	s = b->slots;
+	notnull(s);
+	while (s->next) s = s->next;
+	eq(s->type, EQUIP_WEAPON);
+	notnull(s->name);
+	require(streq(s->name, "weapon"));
+	null(s->obj);
+	/* Try adding another slot. */
+	r = parser_parse(p, "slot:BOW:shooting");
+	eq(r, PARSE_ERROR_NONE);
+	b = (struct player_body*) parser_priv(p);
+	notnull(b);
+	eq(b->count, old_count + 2);
+	s = b->slots;
+	notnull(s);
+	while (s->next) s = s->next;
+	eq(s->type, EQUIP_BOW);
+	notnull(s->name);
+	require(streq(s->name, "shooting"));
+	null(s->obj);
+	ok;
+}
+
+static int test_slot_bad0(void *state) {
+	struct parser *p = (struct parser*) state;
+	/* Try a bad type of slot. */
+	enum parser_error r = parser_parse(p, "slot:XYZZY:left nostril");
+
+	eq(r, PARSE_ERROR_INVALID_FLAG);
+	ok;
+}
+
+static int test_complete0(void *state) {
+	const char *lines[] = {
+		"body:Humanoid",
+		"slot:WEAPON:weapon",
+		"slot:RING:right hand",
+		"slot:RING:left hand",
+		"slot:LIGHT:light",
+		"slot:BODY_ARMOR:body",
+		"slot:CLOAK:back",
+		"slot:HAT:head"
+	};
+	struct parser *p = (struct parser*) state;
+	struct player_body *b;
+	struct equip_slot *s;
+	int i;
+
+	for (i = 0; i < (int) N_ELEMENTS(lines); ++i) {
+		enum parser_error r = parser_parse(p, lines[i]);
+
+		eq(r, PARSE_ERROR_NONE);
+	}
+	b = (struct player_body*) parser_priv(p);
+	notnull(b);
+	require(streq(b->name, "Humanoid"));
+	s = b->slots;
+	notnull(s);
+	eq(s->type, EQUIP_WEAPON);
+	notnull(s->name);
+	require(streq(s->name, "weapon"));
+	null(s->obj);
+	s = s->next;
+	notnull(s);
+	eq(s->type, EQUIP_RING);
+	notnull(s->name);
+	require(streq(s->name, "right hand"));
+	null(s->obj);
+	s = s->next;
+	notnull(s);
+	eq(s->type, EQUIP_RING);
+	notnull(s->name);
+	require(streq(s->name, "left hand"));
+	null(s->obj);
+	s = s->next;
+	notnull(s);
+	eq(s->type, EQUIP_LIGHT);
+	notnull(s->name);
+	require(streq(s->name, "light"));
+	null(s->obj);
+	s = s->next;
+	notnull(s);
+	eq(s->type, EQUIP_BODY_ARMOR);
+	notnull(s->name);
+	require(streq(s->name, "body"));
+	null(s->obj);
+	s = s->next;
+	notnull(s);
+	eq(s->type, EQUIP_CLOAK);
+	notnull(s->name);
+	require(streq(s->name, "back"));
+	null(s->obj);
+	s = s->next;
+	notnull(s);
+	eq(s->type, EQUIP_HAT);
+	notnull(s->name);
+	require(streq(s->name, "head"));
+	null(s->obj);
+	s = s->next;
+	null(s);
+	ok;
+}
+
+const char *suite_name = "parse/body";
+/*
+ * test_missing_record_header0() has to be before test_body0() and
+ * test_complete0().
+ * test_slot0() and test_slot_bad0() have to be after test_body0().
+ */
+struct test tests[] = {
+	{ "missing_record_header0", test_missing_record_header0 },
+	{ "body0", test_body0 },
+	{ "slot0", test_slot0 },
+	{ "slot_bad0", test_slot_bad0 },
+	{ "complete0", test_complete0 },
+	{ NULL, NULL }
+};

--- a/src/tests/parse/f-info.c
+++ b/src/tests/parse/f-info.c
@@ -11,7 +11,7 @@
 
 
 int setup_tests(void **state) {
-	*state = init_parse_feat();
+	*state = feat_parser.init();
 	return !*state;
 }
 
@@ -52,6 +52,30 @@ static int test_missing_header_record0(void *state) {
 	r = parser_parse(p, "flags:LOS | PASSABLE");
 	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
 	r = parser_parse(p, "info:0:3:0");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "desc:A door that is already open.");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "walk-msg:It looks dangerous.  Really enter? ");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "run-msg:Lava blocks your path.  Step into it ? ");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "hurt-msg:The lave burns you!");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "dig-msg:You clear the rubble.");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "fail-msg:You are unable to shift the rubble "
+		"with your {name}.");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p,
+		"str-msg:You are not strong enough to shift the rubble.");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "die-msg:burning to a cinder in lava");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "confused-msg:bangs into a door");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "look-prefix:the entrance to the");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "look-in-preposition:at");
 	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
 	ok;
 }
@@ -179,6 +203,15 @@ static int test_flags0(void *state) {
 	flag_on_dbg(eflags, TF_SIZE, TF_PERMANENT, "eflags", "TF_PERMANENT");
 	flag_on_dbg(eflags, TF_SIZE, TF_DOWNSTAIR, "eflags", "TF_DOWNSTAIR");
 	require(flag_is_equal(f->flags, eflags, TF_SIZE));
+	ok;
+}
+
+static int test_flags_bad0(void *state) {
+	struct parser *p = (struct parser*) state;
+	/* Try an unrecognized flag. */
+	enum parser_error r = parser_parse(p, "flags:XYZZY");
+
+	eq(r, PARSE_ERROR_INVALID_FLAG);
 	ok;
 }
 
@@ -389,6 +422,7 @@ struct test tests[] = {
 	{ "mimic0", test_mimic0 },
 	{ "priority0", test_priority0 },
 	{ "flags0", test_flags0 },
+	{ "flags_bad0", test_flags_bad0 },
 	{ "info0", test_info0 },
 	{ "desc0", test_desc0 },
 	{ "walk_msg0", test_walk_msg0 },

--- a/src/tests/parse/flavor.c
+++ b/src/tests/parse/flavor.c
@@ -21,7 +21,7 @@ struct object_kind dummy_kinds[] = {
 };
 
 int setup_tests(void **state) {
-	*state = init_parse_flavor();
+	*state = flavor_parser.init();
 	/*
 	 * Do minimal setup so sval lookups work for the tests of fixed flavors.
 	 */
@@ -61,7 +61,7 @@ static int test_flavor0(void *state) {
 	struct flavor *f;
 
 	eq(r, PARSE_ERROR_NONE);
-	f = (struct flavor*) parser_priv(state);
+	f = (struct flavor*) parser_priv(p);
 	notnull(f);
 	eq(f->fidx, 2);
 	eq(f->tval, TV_LIGHT);
@@ -114,13 +114,24 @@ static int test_fixed0(void *state) {
 	ok;
 }
 
+static int test_kind_bad0(void *state) {
+	struct parser *p = (struct parser*) state;
+	/* Try an invalid tval. */
+	enum parser_error r = parser_parse(p, "kind:xyzzy:'");
+
+	eq(r, PARSE_ERROR_UNRECOGNISED_TVAL);
+	ok;
+}
+
 const char *suite_name = "parse/flavor";
 /*
- * test_flavor0() and test_fixed0() have to be after test_kind0().
+ * test_flavor0() and test_fixed0() have to be after test_kind0().  Run
+ * test_kind_bad0() last to avoid potential effects on other tests.
  */
 struct test tests[] = {
 	{ "kind0", test_kind0 },
 	{ "flavor0", test_flavor0 },
 	{ "fixed0", test_fixed0 },
+	{ "kind_bad0", test_kind_bad0 },
 	{ NULL, NULL }
 };

--- a/src/tests/parse/h-info.c
+++ b/src/tests/parse/h-info.c
@@ -7,7 +7,7 @@
 #include "player.h"
 
 int setup_tests(void **state) {
-	*state = init_parse_history();
+	*state = history_parser.init();
 	return !*state;
 }
 

--- a/src/tests/parse/house-info.c
+++ b/src/tests/parse/house-info.c
@@ -1,67 +1,173 @@
 /* parse/house-info */
+/* Exercise parsing use for house.txt. */
 
 #include "unit-test.h"
 
 #include "init.h"
-#include "obj-properties.h"
-#include "object.h"
-#include "obj-tval.h"
-#include "obj-util.h"
 #include "player.h"
+#include "z-form.h"
+
+/* Set up a minimal set of races to test race lookups. */
+static char dummy_race_name_1[16] = "Noldor";
+static char dummy_race_name_2[16] = "Sindar";
+static char dummy_race_name_3[16] = "Naugrim";
+static char dummy_race_name_4[16] = "Edain";
+static struct player_race dummy_races[4];
 
 int setup_tests(void **state) {
-	*state = init_parse_house();
+	*state = house_parser.init();
+	dummy_races[0].name = dummy_race_name_1;
+	dummy_races[0].next = &dummy_races[1];
+	dummy_races[1].name = dummy_race_name_2;
+	dummy_races[1].next = &dummy_races[2];
+	dummy_races[2].name = dummy_race_name_3;
+	dummy_races[2].next = &dummy_races[3];
+	dummy_races[3].name = dummy_race_name_4;
+	dummy_races[3].next = NULL;
+	races = dummy_races;
 	return !*state;
 }
 
 int teardown_tests(void *state) {
-	struct player_house *h = parser_priv(state);
-	string_free((char *)h->name);
-	mem_free(h);
-	parser_destroy(state);
-	return 0;
+	struct parser *p = (struct parser*) state;
+	int r = 0;
+
+	if (house_parser.finish(p)) {
+		r = 1;
+	}
+	house_parser.cleanup();
+	return r;
+}
+
+static int test_missing_header_record0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r;
+
+	null(parser_priv(p));
+	r = parser_parse(p, "alt-name:Feanor's House");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "short-name:Feanor");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "race:Noldor");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "stats:0:1:0:0");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "skills:0:0:0:0:0:0:1:0");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "player-flags:BLADE_PROFICIENCY");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "desc:Feanor was the greatest of the Noldor, ");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	ok;
 }
 
 static int test_name0(void *state) {
-	enum parser_error r = parser_parse(state, "name:House of Fingolfin");
+	struct parser *p = (struct parser*) state;
+	enum parser_error r = parser_parse(p, "name:House of Fingolfin");
 	struct player_house *h;
+	int i;
 
 	eq(r, PARSE_ERROR_NONE);
-	h = parser_priv(state);
-	require(h);
+	h = (struct player_house*) parser_priv(p);
+	notnull(h);
+	notnull(h->name);
 	require(streq(h->name, "House of Fingolfin"));
+	null(h->race);
+	null(h->alt_name);
+	null(h->short_name);
+	null(h->desc);
+	for (i = 0; i < STAT_MAX; ++i) {
+		eq(h->stat_adj[i], 0);
+	}
+	for (i = 0; i < SKILL_MAX; ++i) {
+		eq(h->skill_adj[i], 0);
+	}
+	require(pf_is_empty(h->pflags));
 	ok;
 }
 
-static int test_name1(void *state) {
-	enum parser_error r = parser_parse(state, "alt-name:Fingolfin's house");
+static int test_alt_name0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r = parser_parse(p, "alt-name:Fingolfin's house");
 	struct player_house *h;
 
 	eq(r, PARSE_ERROR_NONE);
-	h = parser_priv(state);
-	require(h);
+	h = (struct player_house*) parser_priv(p);
+	notnull(h);
+	notnull(h->alt_name);
 	require(streq(h->alt_name, "Fingolfin's house"));
+	/*
+	 * Specifying multiple times fo the same house should not leak
+	 * memory.
+	 */
+	r = parser_parse(p, "alt-name:Feanor's house");
+	eq(r, PARSE_ERROR_NONE);
+	h = (struct player_house*) parser_priv(p);
+	notnull(h);
+	notnull(h->alt_name);
+	require(streq(h->alt_name, "Feanor's house"));
 	ok;
 }
 
-static int test_name2(void *state) {
-	enum parser_error r = parser_parse(state, "short-name:Fingolfin");
+static int test_short_name0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r = parser_parse(p, "short-name:Fingolfin");
 	struct player_house *h;
 
 	eq(r, PARSE_ERROR_NONE);
-	h = parser_priv(state);
-	require(h);
+	h = (struct player_house*) parser_priv(p);
+	notnull(h);
+	notnull(h->short_name);
 	require(streq(h->short_name, "Fingolfin"));
+	/*
+	 * Specifying multiple times for the same house should not leak
+	 * memory.
+	 */
+	r = parser_parse(p, "short-name:Feanor");
+	eq(r, PARSE_ERROR_NONE);
+	h = (struct player_house*) parser_priv(p);
+	notnull(h);
+	notnull(h->short_name);
+	require(streq(h->short_name, "Feanor"));
+	ok;
+}
+
+static int test_race0(void *state) {
+	struct parser *p = (struct parser*) state;
+	char buffer[80];
+	int i;
+
+	for (i = 0; i < (int) N_ELEMENTS(dummy_races); ++i) {
+		struct player_house *h;
+		enum parser_error r;
+
+		strnfmt(buffer, sizeof(buffer), "race:%s", dummy_races[i].name);
+		r = parser_parse(p, buffer);
+		eq(r, PARSE_ERROR_NONE);
+		h = (struct player_house*) parser_priv(p);
+		notnull(h);
+		ptreq(h->race, &dummy_races[i]);
+	}
+	ok;
+}
+
+static int test_race_bad0(void *state) {
+	struct parser *p = (struct parser*) state;
+	/* Try an unrecognized race. */
+	enum parser_error r = parser_parse(p, "race:Xyzzy");
+
+	eq(r, PARSE_ERROR_INVALID_PLAYER_RACE);
 	ok;
 }
 
 static int test_stats0(void *state) {
-	enum parser_error r = parser_parse(state, "stats:3:-3:2:-2");
+	struct parser *p = (struct parser*) state;
+	enum parser_error r = parser_parse(p, "stats:3:-3:2:-2");
 	struct player_house *h;
 
 	eq(r, PARSE_ERROR_NONE);
-	h = parser_priv(state);
-	require(h);
+	h = (struct player_house*) parser_priv(p);
+	notnull(h);
 	eq(h->stat_adj[STAT_STR], 3);
 	eq(h->stat_adj[STAT_DEX], -3);
 	eq(h->stat_adj[STAT_CON], 2);
@@ -70,41 +176,159 @@ static int test_stats0(void *state) {
 }
 
 static int test_skills0(void *state) {
-	enum parser_error r = parser_parse(state, "skills:1:2:-1:0:1:1:0:0");
+	struct parser *p = (struct parser*) state;
+	enum parser_error r = parser_parse(p, "skills:1:2:-1:-2:3:4:-4:-3");
 	struct player_house *h;
 
 	eq(r, PARSE_ERROR_NONE);
-	h = parser_priv(state);
-	require(h);
+	h = (struct player_house*) parser_priv(p);
+	notnull(h);
 	eq(h->skill_adj[SKILL_MELEE], 1);
 	eq(h->skill_adj[SKILL_ARCHERY], 2);
 	eq(h->skill_adj[SKILL_EVASION], -1);
-	eq(h->skill_adj[SKILL_STEALTH], 0);
-	eq(h->skill_adj[SKILL_PERCEPTION], 1);
-	eq(h->skill_adj[SKILL_WILL], 1);
-	eq(h->skill_adj[SKILL_SMITHING], 0);
-	eq(h->skill_adj[SKILL_SONG], 0);
+	eq(h->skill_adj[SKILL_STEALTH], -2);
+	eq(h->skill_adj[SKILL_PERCEPTION], 3);
+	eq(h->skill_adj[SKILL_WILL], 4);
+	eq(h->skill_adj[SKILL_SMITHING], -4);
+	eq(h->skill_adj[SKILL_SONG], -3);
 	ok;
 }
 
 static int test_flags0(void *state) {
-	enum parser_error r = parser_parse(state, "player-flags:AXE_PROFICIENCY | BLADE_PROFICIENCY");
+	struct parser *p = (struct parser*) state;
+	struct player_house *h = (struct player_house*) parser_priv(p);
+	enum parser_error r;
+	bitflag eflags[PF_SIZE];
+
+	notnull(h);
+	pf_wipe(h->pflags);
+	/* Try with no flags. */
+	r = parser_parse(p, "player-flags:");
+	eq(r, PARSE_ERROR_NONE);
+	h = (struct player_house*) parser_priv(p);
+	notnull(h);
+	require(pf_is_empty(h->pflags));
+	/* Try with a single flag. */
+	r = parser_parse(p, "player-flags:BLADE_PROFICIENCY");
+	eq(r, PARSE_ERROR_NONE);
+	/* Check that multiple directives append the flags. */
+	r = parser_parse(p, "player-flags:AXE_PROFICIENCY");
+	eq(r, PARSE_ERROR_NONE);
+	h = (struct player_house*) parser_priv(p);
+	notnull(h);
+	pf_wipe(eflags);
+	pf_on(eflags, PF_BLADE_PROFICIENCY);
+	pf_on(eflags, PF_AXE_PROFICIENCY);
+	require(pf_is_equal(h->pflags, eflags));
+	/* Try with multiple flags at once. */
+	pf_wipe(h->pflags);
+	r = parser_parse(p, "player-flags:AXE_PROFICIENCY | BLADE_PROFICIENCY");
+	eq(r, PARSE_ERROR_NONE);
+	h = (struct player_house*) parser_priv(p);
+	notnull(h);
+	require(pf_is_equal(h->pflags, eflags));
+	ok;
+}
+
+static int test_flags_bad0(void *state) {
+	struct parser *p = (struct parser*) state;
+	/* Try with an unrecognized flag. */
+	enum parser_error r = parser_parse(p, "player-flags:XYZZY");
+
+	eq(r, PARSE_ERROR_INVALID_FLAG);
+	ok;
+}
+
+static int test_desc0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r = parser_parse(p,
+		"desc:Fingolfin led his house into Beleriand ");
 	struct player_house *h;
 
 	eq(r, PARSE_ERROR_NONE);
-	h = parser_priv(state);
-	require(h);
-	require(h->pflags);
+	h = (struct player_house*) parser_priv(p);
+	notnull(h);
+	notnull(h->desc);
+	require(streq(h->desc, "Fingolfin led his house into Beleriand "));
+	/* Check that a second directive is appended to the first. */
+	r = parser_parse(p,
+		"desc:to protect its peoples from the shadow of Morgoth.");
+	eq(r, PARSE_ERROR_NONE);
+	h = (struct player_house*) parser_priv(p);
+	notnull(h);
+	notnull(h->desc);
+	require(streq(h->desc, "Fingolfin led his house into Beleriand"
+		"to protect its peoples from the shadow of Morgoth."));
+	ok;
+}
+
+static int test_complete0(void *state) {
+	const char *lines[] = {
+		"name:Of the Falas",
+		"alt-name:the Falas",
+		"short-name:Falathrim",
+		"race:Sindar",
+		"stats:0:1:0:0",
+		"skills:0:1:0:0:0:0:0:0",
+		"desc:When Thingol met with Melian under the wheeling stars, ",
+		"desc:many of his folk despaired of finding him again and ",
+		"desc:journeyed to the shore, the Falas, to set sail to ",
+		"desc:Valinor. Some tarried there and dwelt in the havens ",
+		"desc:on the edge of Middle-Earth with their lord, Cirdan, ",
+		"desc:the shipbuilder."
+	};
+	struct parser *p = (struct parser*) state;
+	struct player_house *h;
+	int i;
+
+	for (i = 0; i < (int) N_ELEMENTS(lines); ++i) {
+		enum parser_error r = parser_parse(p, lines[i]);
+
+		eq(r, PARSE_ERROR_NONE);
+	}
+	h = (struct player_house*) parser_priv(p);
+	notnull(h);
+	notnull(h->name);
+	require(streq(h->name, "Of the Falas"));
+	notnull(h->alt_name);
+	require(streq(h->alt_name, "the Falas"));
+	notnull(h->short_name);
+	require(streq(h->short_name, "Falathrim"));
+	notnull(h->desc);
+	require(streq(h->desc, "When Thingol met with Meial under the wheeling "
+		"stars, many of his folk despaired of finding him again and "
+		"journeyed to the shore, the Falas, to set sail to Valinor. "
+		"Some tarried there and dwelt in the havens on the edge of "
+		"Middle-Earth with their lord, Cirdan, the shipbuilder."));
+	for (i = 0; i < STAT_MAX; ++i) {
+		eq(h->stat_adj[i], (i == STAT_DEX) ? 1 : 0);
+	}
+	for (i = 0; i < SKILL_MAX; ++i) {
+		eq(h->skill_adj[i], (i == SKILL_ARCHERY) ? 1 : 0);
+	}
+	pf_is_empty(h->pflags);
 	ok;
 }
 
 const char *suite_name = "parse/house-info";
+/*
+ * test_missing_header_record0() has to be before test_name0() and
+ * test_complete0().
+ * Unless otherwise indicated, all other functions have to be after
+ * test_name0().
+ */
 struct test tests[] = {
+	{ "missing_header_record0", test_missing_header_record0 },
 	{ "name0", test_name0 },
-	{ "name1", test_name1 },
-	{ "name2", test_name2 },
+	{ "alt_name0", test_alt_name0 },
+	{ "short_name0", test_short_name0 },
+	{ "race0", test_race0 },
+	{ "race_bad0", test_race_bad0 },
 	{ "stats0", test_stats0 },
 	{ "skills0", test_skills0 },
 	{ "flags0", test_flags0 },
+	{ "flags_bad0", test_flags_bad0 },
+	{ "desc0", test_desc0 },
+	{ "complete0", test_complete0 },
 	{ NULL, NULL }
 };

--- a/src/tests/parse/names.c
+++ b/src/tests/parse/names.c
@@ -3,6 +3,7 @@
 #include "unit-test.h"
 #include "init.h"
 #include "randname.h"
+#include "z-form.h"
 
 struct name {
 	struct name *next;
@@ -16,7 +17,7 @@ struct names_parse {
 };
 
 int setup_tests(void **state) {
-	*state = init_parse_names();
+	*state = names_parser.init();
 	return !*state;
 }
 
@@ -67,6 +68,19 @@ static int test_word1(void *state) {
 	ok;
 }
 
+static int test_section_bad0(void *state) {
+	struct parser *p = (struct parser*) state;
+	char buffer[80];
+	size_t nc;
+	enum parser_error r;
+
+	nc = strnfmt(buffer, sizeof(buffer), "section:%d", RANDNAME_NUM_TYPES);
+	require(nc < sizeof(buffer) - 1);
+	r = parser_parse(p, buffer);
+	eq(r, PARSE_ERROR_OUT_OF_BOUNDS);
+	ok;
+}
+
 const char *suite_name = "parse/names";
 struct test tests[] = {
 	{ "section0", test_section0 },
@@ -75,5 +89,6 @@ struct test tests[] = {
 	{ "section1", test_section1 },
 	{ "word1", test_word1 },
 
+	{ "section_bad0", test_section_bad0 },
 	{ NULL, NULL }
 };

--- a/src/tests/parse/partrap.c
+++ b/src/tests/parse/partrap.c
@@ -1,0 +1,952 @@
+/* parse/partrap */
+/* Exercise parsing used for trap.txt. */
+
+#include "unit-test.h"
+
+struct chunk;
+#include "effects.h"
+#include "init.h"
+#include "object.h"
+#include "player.h"
+#include "player-timed.h"
+#include "project.h"
+#include "trap.h"
+#include "z-color.h"
+
+int setup_tests(void **state) {
+	*state = trap_parser.init();
+	/* trap_parser.finish() needs z_info. */
+	z_info = mem_zalloc(sizeof(*z_info));
+	return !*state;
+}
+
+int teardown_tests(void *state) {
+	struct parser *p = (struct parser*) state;
+	int r = 0;
+
+	if (trap_parser.finish(p)) {
+		r = 1;
+	}
+	trap_parser.cleanup();
+	mem_free(z_info);
+	return r;
+}
+
+static int test_missing_header_record0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r;
+
+	null(parser_priv(p));
+	r = parser_parse(p, "graphics:;:G");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "rarity:2");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "min-depth:5");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "max-depth:18");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "power:6");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "stealth:-10");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "flags:TRAP | FLOOR | PIT");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "effect:DAMAGE");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "dice:4d$S");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "expr:S:DUNGEON_LEVEL:/ 2");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "effect-xtra:TIMED_INC:CUT");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "dice-xtra:8d$S");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "expr-xtra:S:DUNGEON_LEVEL:/ 25 + 3");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "desc:A hole dug to snare the unwary.");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "msg:You fall into a pit!");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "msg2:You fall through...");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p,
+		"msg3:... and land somewhere deeper in the Iron Hells.");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "msg-vis:There is a searing flash of light!");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "msg-silence:You hear the muffled toll "
+		"of a bell above your head.");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "msg-good:You float gently to the bottom of "
+		"the pit.");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "msg-bad:A small dart hits you!");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "msg-xtra:You are impaled!");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	ok;
+}
+
+static int test_name0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r = parser_parse(p, "name:test trap:test trap 1");
+	struct trap_kind *t;
+
+	eq(r, PARSE_ERROR_NONE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	notnull(t->name);
+	require(streq(t->name, "test trap"));
+	null(t->text);
+	notnull(t->desc);
+	require(streq(t->desc, "test trap 1"));
+	null(t->msg);
+	null(t->msg2);
+	null(t->msg3);
+	null(t->msg_vis);
+	null(t->msg_silence);
+	null(t->msg_good);
+	null(t->msg_bad);
+	null(t->msg_xtra);
+	eq(t->d_attr, 0);
+	eq(t->d_char, 0);
+	eq(t->rarity, 0);
+	eq(t->min_depth, 0);
+	eq(t->max_depth, 0);
+	eq(t->power, 0);
+	eq(t->stealth, 0);
+	require(trf_is_empty(t->flags));
+	null(t->effect);
+	null(t->effect_xtra);
+	ok;
+}
+
+static int test_graphics0(void *state) {
+	struct parser *p = (struct parser*) state;
+	/* Try with a full name for the color. */
+	enum parser_error r = parser_parse(p, "graphics:^:Red");
+	struct trap_kind *t;
+
+	eq(r, PARSE_ERROR_NONE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	eq(t->d_attr, COLOUR_RED);
+	eq(t->d_char, L'^');
+	/* Check that matching the color's full name is case-insensitive. */
+	r = parser_parse(p, "graphics:%:light green");
+	eq(r, PARSE_ERROR_NONE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	eq(t->d_attr, COLOUR_L_GREEN);
+	eq(t->d_char, L'%');
+	/* Try with a single letter code for the color. */
+	r = parser_parse(p, "graphics:_:s");
+	eq(r, PARSE_ERROR_NONE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	eq(t->d_attr, COLOUR_SLATE);
+	eq(t->d_char, L'_');
+	ok;
+}
+
+static int test_rarity0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r = parser_parse(p, "rarity:2");
+	struct trap_kind *t;
+
+	eq(r, PARSE_ERROR_NONE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	eq(t->rarity, 2);
+	ok;
+}
+
+static int test_min_depth0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r = parser_parse(p, "min-depth:5");
+	struct trap_kind *t;
+
+	eq(r, PARSE_ERROR_NONE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	eq(t->min_depth, 5);
+	ok;
+}
+
+static int test_max_depth0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r = parser_parse(p, "max-depth:18");
+	struct trap_kind *t;
+
+	eq(r, PARSE_ERROR_NONE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	eq(t->max_depth, 18);
+	ok;
+}
+
+static int test_power0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r = parser_parse(p, "power:8");
+	struct trap_kind *t;
+
+	eq(r, PARSE_ERROR_NONE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	eq(t->power, 8);
+	ok;
+}
+
+static int test_power_bad0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r = parser_parse(p, "power:-2");
+
+	eq(r, PARSE_ERROR_INVALID_VALUE);
+	r = parser_parse(p, "power:255");
+	eq(r, PARSE_ERROR_INVALID_VALUE);
+	r = parser_parse(p, "power:32853");
+	eq(r, PARSE_ERROR_INVALID_VALUE);
+	r = parser_parse(p, "power:-750");
+	eq(r, PARSE_ERROR_INVALID_VALUE);
+	ok;
+}
+
+static int test_stealth0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r = parser_parse(p, "stealth:-10");
+	struct trap_kind *t;
+
+	eq(r, PARSE_ERROR_NONE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	eq(t->stealth, -10);
+	ok;
+}
+
+static int test_flags0(void *state) {
+	struct parser *p = (struct parser*) state;
+	struct trap_kind *t = (struct trap_kind*) parser_priv(p);
+	enum parser_error r;
+	bitflag eflags[TRF_SIZE];
+
+	notnull(t);
+	trf_wipe(t->flags);
+	/* Try with no flags. */
+	r = parser_parse(p, "flags:");
+	eq(r, PARSE_ERROR_NONE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	require(trf_is_empty(t->flags));
+	/* Try with a single flag. */
+	r = parser_parse(p, "flags:TRAP");
+	eq(r, PARSE_ERROR_NONE);
+	/* Try with multiple flags at once. */
+	r = parser_parse(p, "flags:FLOOR | VISIBLE");
+	eq(r, PARSE_ERROR_NONE);
+	trf_wipe(eflags);
+	trf_on(eflags, TRF_TRAP);
+	trf_on(eflags, TRF_FLOOR);
+	trf_on(eflags, TRF_VISIBLE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	require(trf_is_equal(t->flags, eflags));
+	ok;
+}
+
+static int test_flags_bad0(void *state) {
+	struct parser *p = (struct parser*) state;
+	/* Try with an unrecognized flag. */
+	enum parser_error r = parser_parse(p, "flags:XYZZY");
+
+	eq(r, PARSE_ERROR_INVALID_FLAG);
+	ok;
+}
+
+static int test_missing_effect0(void *state) {
+	struct parser *p = (struct parser*) state;
+	struct trap_kind *t = (struct trap_kind*) parser_priv(p);
+	enum parser_error r;
+
+	notnull(t);
+	null(t->effect);
+	/*
+	 * Specifying effect details without an effect should not signal an
+	 * error and leave the trap unmodified.
+	 */
+	r = parser_parse(p, "dice:4+5d$S");
+	eq(r, PARSE_ERROR_NONE);
+	r = parser_parse(p, "expr:S:DUNGEON_LEVEL:/ 10 + 2");
+	eq(r, PARSE_ERROR_NONE);
+	ok;
+}
+
+static int test_effect0(void *state) {
+	struct parser *p = (struct parser*) state;
+	/* Try with an effect that has no subtype, radius or other. */
+	enum parser_error r = parser_parse(p, "effect:DAMAGE");
+	struct trap_kind *t;
+	struct effect *e;
+
+	eq(r, PARSE_ERROR_NONE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	e = t->effect;
+	notnull(e);
+	while (e->next) e = e->next;
+	eq(e->index, EF_DAMAGE);
+	null(e->dice);
+	eq(e->subtype, 0);
+	eq(e->radius, 0);
+	eq(e->other, 0);
+	null(e->msg);
+	/* Try with an effect that has a subtype but no radius or other. */
+	r = parser_parse(p, "effect:TIMED_INC:SLOW");
+	eq(r, PARSE_ERROR_NONE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	e = t->effect;
+	notnull(e);
+	while (e->next) e = e->next;
+	eq(e->index, EF_TIMED_INC);
+	null(e->dice);
+	eq(e->subtype, TMD_SLOW);
+	eq(e->radius, 0);
+	eq(e->other, 0);
+	null(e->msg);
+	/* Try with an effect that has a subtype and radius but no other. */
+	r = parser_parse(p, "effect:SPOT:FIRE:1");
+	eq(r, PARSE_ERROR_NONE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	e = t->effect;
+	notnull(e);
+	while (e->next) e = e->next;
+	eq(e->index, EF_SPOT);
+	null(e->dice);
+	eq(e->subtype, PROJ_FIRE);
+	eq(e->radius, 1);
+	eq(e->other, 0);
+	null(e->msg);
+	/* Try with an effect that has a subtype, radius, and other. */
+	r = parser_parse(p, "effect:SPOT:ACID:2:10");
+	eq(r, PARSE_ERROR_NONE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	e = t->effect;
+	notnull(e);
+	while (e->next) e = e->next;
+	eq(e->index, EF_SPOT);
+	null(e->dice);
+	eq(e->subtype, PROJ_ACID);
+	eq(e->radius, 2);
+	eq(e->other, 10);
+	null(e->msg);
+	ok;
+}
+
+static int test_effect_bad0(void *state) {
+	struct parser *p = (struct parser*) state;
+	/* Try with an unrecognized effect. */
+	enum parser_error r = parser_parse(p, "effect:XYZZY");
+
+	eq(r, PARSE_ERROR_INVALID_EFFECT);
+	/* Try with a recognized effect but an unrecognized subtype. */
+	r = parser_parse(p, "effect:TIMED_INC:XYZZY");
+	eq(r, PARSE_ERROR_INVALID_VALUE);
+	ok;
+}
+
+static int test_dice0(void *state) {
+	struct parser *p = (struct parser*) state;
+	/* Set up a new effect. */
+	enum parser_error r = parser_parse(p, "effect:DAMAGE");
+	struct trap_kind *t;
+	struct effect *e;
+
+	eq(r, PARSE_ERROR_NONE);
+	r = parser_parse(p, "dice:5+2d8M30");
+	eq(r, PARSE_ERROR_NONE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	e = t->effect;
+	notnull(e);
+	while (e->next) e = e->next;
+	notnull(e->dice);
+	require(dice_test_values(e->dice, 5, 2, 8, 30));
+	ok;
+}
+
+static int test_dice_bad0(void *state) {
+	struct parser *p = (struct parser*) state;
+	/* Set up a new effect. */
+	enum parser_error r = parser_parse(p, "effect:DAMAGE");
+
+	eq(r, PARSE_ERROR_NONE);
+	r = parser_parse(p, "dice:1d8+7");
+	eq(r, PARSE_ERROR_INVALID_DICE);
+	ok;
+}
+
+static int test_missing_dice0(void *state) {
+	struct parser *p = (struct parser*) state;
+	/* Set up a new effect. */
+	enum parser_error r = parser_parse(p, "effect:DAMAGE");
+	struct trap_kind *t;
+
+	eq(r, PARSE_ERROR_NONE);
+	/*
+	 * Specifying an expression without dice should not flag an error and
+	 * not modify the trap.
+	 */
+	r = parser_parse(p, "expr:S:DUNGEON_LEVEL:/ 5 + 2");
+	eq(r, PARSE_ERROR_NONE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	notnull(t->effect);
+	null(t->effect->dice);
+	ok;
+}
+
+static int test_expr0(void *state) {
+	struct parser *p = (struct parser*) state;
+	/* Set up a new effect with dice. */
+	enum parser_error r = parser_parse(p, "effect:DAMAGE");
+
+	eq(r, PARSE_ERROR_NONE);
+	r = parser_parse(p, "dice:$B+5d$S");
+	eq(r, PARSE_ERROR_NONE);
+	r = parser_parse(p, "expr:B:DUNGEON_LEVEL:/ 10 + 8");
+	eq(r, PARSE_ERROR_NONE);
+	ok;
+}
+
+static int test_expr_bad0(void *state) {
+	struct parser *p = (struct parser*) state;
+	/* Set up a new effect with dice. */
+	enum parser_error r = parser_parse(p, "effect:DAMAGE");
+
+	eq(r, PARSE_ERROR_NONE);
+	r = parser_parse(p, "dice:$B+10d$S");
+	eq(r, PARSE_ERROR_NONE);
+	/* Try an expression with invalid operations. */
+	r = parser_parse(p, "expr:S:DUNGEON_LEVEL:^ 2");
+	eq(r, PARSE_ERROR_BAD_EXPRESSION_STRING);
+	/* Try to bind the expression to a variable that is not in the dice. */
+	r = parser_parse(p, "expr:M:DUNGEON_LEVEL:/ 8 + 1");
+	eq(r, PARSE_ERROR_UNBOUND_EXPRESSION);
+	ok;
+}
+
+static int test_missing_effect_xtra0(void *state) {
+	struct parser *p = (struct parser*) state;
+	struct trap_kind *t = (struct trap_kind*) parser_priv(p);
+	enum parser_error r;
+
+	notnull(t);
+	null(t->effect_xtra);
+	/*
+	 * Specifying effect details without an effect should not signal an
+	 * error and leave the trap unmodified.
+	 */
+	r = parser_parse(p, "dice-xtra:$B+5d4");
+	eq(r, PARSE_ERROR_NONE);
+	r = parser_parse(p, "expr-xtra:B:DUNGEON_LEVEL:/ 10 + 8");
+	eq(r, PARSE_ERROR_NONE);
+	ok;
+}
+
+static int test_effect_xtra0(void *state) {
+	struct parser *p = (struct parser*) state;
+	/* Try with an effect that has no subtype, radius or other. */
+	enum parser_error r = parser_parse(p, "effect-xtra:AGGRAVATE");
+	struct trap_kind *t;
+	struct effect *e;
+
+	eq(r, PARSE_ERROR_NONE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	e = t->effect_xtra;
+	notnull(e);
+	while (e->next) e = e->next;
+	eq(e->index, EF_AGGRAVATE);
+	null(e->dice);
+	eq(e->subtype, 0);
+	eq(e->radius, 0);
+	eq(e->other, 0);
+	null(e->msg);
+	/* Try with an effect that has a subtype but no radius or other. */
+	r = parser_parse(p, "effect-xtra:DRAIN_STAT:STR");
+	eq(r, PARSE_ERROR_NONE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	e = t->effect_xtra;
+	notnull(e);
+	while (e->next) e = e->next;
+	eq(e->index, EF_DRAIN_STAT);
+	null(e->dice);
+	eq(e->subtype, STAT_STR);
+	eq(e->radius, 0);
+	eq(e->other, 0);
+	null(e->msg);
+	/* Try with an effect that has a subtype and radius but no other. */
+	r = parser_parse(p, "effect-xtra:SPOT:ACID:1");
+	eq(r, PARSE_ERROR_NONE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	e = t->effect_xtra;
+	notnull(e);
+	while (e->next) e = e->next;
+	eq(e->index, EF_SPOT);
+	null(e->dice);
+	eq(e->subtype, PROJ_ACID);
+	eq(e->radius, 1);
+	eq(e->other, 0);
+	null(e->msg);
+	/* Try with an effect that has a subtype, radius, and other. */
+	r = parser_parse(p, "effect-xtra:SPHERE:FIRE:4:5");
+	eq(r, PARSE_ERROR_NONE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	e = t->effect_xtra;
+	notnull(e);
+	while (e->next) e = e->next;
+	eq(e->index, EF_SPHERE);
+	null(e->dice);
+	eq(e->subtype, PROJ_FIRE);
+	eq(e->radius, 4);
+	eq(e->other, 5);
+	null(e->msg);
+	ok;
+}
+
+static int test_effect_xtra_bad0(void *state) {
+	struct parser *p = (struct parser*) state;
+	/* Try with an unrecognized effect. */
+	enum parser_error r = parser_parse(p, "effect-xtra:XYZZY");
+
+	eq(r, PARSE_ERROR_INVALID_EFFECT);
+	/* Try with a recognized effect but an unrecognized subtype. */
+	r = parser_parse(p, "effect-xtra:BOLT:XYZZY");
+	eq(r, PARSE_ERROR_INVALID_VALUE);
+	ok;
+}
+
+static int test_dice_xtra0(void *state) {
+	struct parser *p = (struct parser*) state;
+	/* Set up a new effect. */
+	enum parser_error r = parser_parse(p, "effect-xtra:DAMAGE");
+	struct trap_kind *t;
+	struct effect *e;
+
+	eq(r, PARSE_ERROR_NONE);
+	r = parser_parse(p, "dice-xtra:10+5d6");
+	eq(r, PARSE_ERROR_NONE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	e = t->effect_xtra;
+	notnull(e);
+	while (e->next) e = e->next;
+	notnull(e->dice);
+	require(dice_test_values(e->dice, 10, 5, 6, 0));
+	ok;
+}
+
+static int test_dice_xtra_bad0(void *state) {
+	struct parser *p = (struct parser*) state;
+	/* Set up a new effect. */
+	enum parser_error r = parser_parse(p, "effect-xtra:DAMAGE");
+
+	eq(r, PARSE_ERROR_NONE);
+	r = parser_parse(p, "dice-xtra:1d6+1d8+1d12");
+	eq(r, PARSE_ERROR_INVALID_DICE);
+	ok;
+}
+
+static int test_missing_dice_xtra0(void *state) {
+	struct parser *p = (struct parser*) state;
+	/* Set up a new effect. */
+	enum parser_error r = parser_parse(p, "effect-xtra:DAMAGE");
+	struct trap_kind *t;
+
+	eq(r, PARSE_ERROR_NONE);
+	/*
+	 * Specifying an expression without dice should not flag an error and
+	 * not modify the trap.
+	 */
+	r = parser_parse(p, "expr-xtra:B:DUNGEON_LEVEL:* 2");
+	eq(r, PARSE_ERROR_NONE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	notnull(t->effect_xtra);
+	null(t->effect_xtra->dice);
+	ok;
+}
+
+static int test_expr_xtra0(void *state) {
+	struct parser *p = (struct parser*) state;
+	/* Set up a new effect with dice. */
+	enum parser_error r = parser_parse(p, "effect-xtra:DAMAGE");
+
+	eq(r, PARSE_ERROR_NONE);
+	r = parser_parse(p, "dice-xtra:$B+5d$S");
+	eq(r, PARSE_ERROR_NONE);
+	r = parser_parse(p, "expr-xtra:S:DUNGEON_LEVEL:/ 20 + 4");
+	eq(r, PARSE_ERROR_NONE);
+	ok;
+}
+
+static int test_expr_xtra_bad0(void *state) {
+	struct parser *p = (struct parser*) state;
+	/* Set up a new effect with dice. */
+	enum parser_error r = parser_parse(p, "effect-xtra:DAMAGE");
+
+	eq(r, PARSE_ERROR_NONE);
+	r = parser_parse(p, "dice-xtra:$B+4d$S");
+	eq(r, PARSE_ERROR_NONE);
+	/* Try an expression with invalid operations. */
+	r = parser_parse(p, "expr-xtra:B:DUNGEON_LEVEL:% 9");
+	eq(r, PARSE_ERROR_BAD_EXPRESSION_STRING);
+	/* Try to bind the expression to a variable that is not in the dice. */
+	r = parser_parse(p, "expr-xtra:T:DUNGEON_LEVEL:+ 1");
+	eq(r, PARSE_ERROR_UNBOUND_EXPRESSION);
+	ok;
+}
+
+static int test_desc0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r = parser_parse(p, "desc:This weakened ceiling "
+		"beam threatens to collapse at any moment.");
+	struct trap_kind *t;
+
+	eq(r, PARSE_ERROR_NONE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	notnull(t->text);
+	require(streq(t->text, "This weakened ceiling beam threatens to "
+		"collapse at any moment."));
+	/* Check that a second directive is appended to the first. */
+	r = parser_parse(p, "desc:  You would prefer not to be nearby when "
+		"it does.");
+	eq(r, PARSE_ERROR_NONE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	notnull(t->text);
+	require(streq(t->text, "This weakened ceiling beam threatens to "
+		"collapse at any moment.  You would prefer not to be nearby "
+		"when it does."));
+	ok;
+}
+
+static int test_msg0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r = parser_parse(p,
+		"msg:Blades whirl around you, slicing your skin!");
+	struct trap_kind *t;
+
+	eq(r, PARSE_ERROR_NONE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	notnull(t->msg);
+	require(streq(t->msg, "Blades whirl around you, slicing your skin!"));
+	/* Check that a second directive is appended to the first. */
+	r = parser_parse(p,
+		"msg:  The air is filled with a fine mist of blood.");
+	eq(r, PARSE_ERROR_NONE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	notnull(t->msg);
+	require(streq(t->msg, "Blades whirl around you, slicing your "
+		"skin!  The air is filled with a fine mist of blood."));
+	ok;
+}
+
+static int test_msg2_0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r = parser_parse(p, "msg2:It becomes very dark...");
+	struct trap_kind *t;
+
+	eq(r, PARSE_ERROR_NONE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	notnull(t->msg2);
+	require(streq(t->msg2, "It becomes very dark..."));
+	/* Check that a second directive is appended to the first. */
+	r = parser_parse(p, "msg2:  Then you hear crunching noises...");
+	eq(r, PARSE_ERROR_NONE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	notnull(t->msg2);
+	require(streq(t->msg2, "It becomes very dark...  Then you hear "
+		"crunching noises..."));
+	ok;
+}
+
+static int test_msg3_0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r = parser_parse(p, "msg3:And a whirling mass of "
+		"scales and claws erupts from the floor.");
+	struct trap_kind *t;
+
+	eq(r, PARSE_ERROR_NONE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	notnull(t->msg3);
+	require(streq(t->msg3, "And a whirling mass of scales and claws "
+		"erupts from the floor."));
+	/* Check that a second directive is appended to the first. */
+	r = parser_parse(p, "msg3:  The mass resolves into several creatures "
+		"that surround you.");
+	eq(r, PARSE_ERROR_NONE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	notnull(t->msg3);
+	require(streq(t->msg3, "And a whirling mass of scales and claws "
+		"erupts from the floor.  The mass resolves into several "
+		"creatures that surround you."));
+	ok;
+}
+
+static int test_msg_vis0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r = parser_parse(p,
+		"msg-vis:There is a searing flash of light!");
+	struct trap_kind *t;
+
+	eq(r, PARSE_ERROR_NONE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	notnull(t->msg_vis);
+	require(streq(t->msg_vis, "There is a searing flash of light!"));
+	/* Check that a second directive is appended to the first. */
+	r = parser_parse(p, "msg-vis:  And a strong smell of burning sulfur.");
+	eq(r, PARSE_ERROR_NONE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	notnull(t->msg_vis);
+	require(streq(t->msg_vis, "There is a searing flash of light!  And a "
+		"strong smell of burning sulfur."));
+	ok;
+}
+
+static int test_msg_silence0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r = parser_parse(p, "msg-silence:You hear the ");
+	struct trap_kind *t;
+
+	eq(r, PARSE_ERROR_NONE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	notnull(t->msg_silence);
+	require(streq(t->msg_silence, "You hear the "));
+	/* Check that a second directive is appended to the first. */
+	r = parser_parse(p,
+		"msg-silence:muffled toll of a bell above your head.");
+	eq(r, PARSE_ERROR_NONE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	notnull(t->msg_silence);
+	require(streq(t->msg_silence, "You hear the muffled toll of a bell "
+		"above your head."));
+	ok;
+}
+
+static int test_msg_good0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r = parser_parse(p,
+		"msg-good:You manage to spring to the side.");
+	struct trap_kind *t;
+
+	eq(r, PARSE_ERROR_NONE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	notnull(t->msg_good);
+	require(streq(t->msg_good, "You manage to spring to the side."));
+	/* Check that a second directive is appended to the first. */
+	r = parser_parse(p,
+		"msg-good:  The floor is not as lucky and shatters.");
+	eq(r, PARSE_ERROR_NONE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	notnull(t->msg_good);
+	require(streq(t->msg_good, "You manage to spring to the side.  The "
+		"floor is not as lucky and shatters."));
+	ok;
+}
+
+static int test_msg_bad0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r = parser_parse(p, "msg-bad:A small dart hits you!");
+	struct trap_kind *t;
+
+	eq(r, PARSE_ERROR_NONE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	notnull(t->msg_bad);
+	require(streq(t->msg_bad, "A small dart hits you!"));
+	/* Check that a second directive is appended to the first. */
+	r = parser_parse(p,
+		"msg-bad:  Numbness spreads from where it pricked you.");
+	eq(r, PARSE_ERROR_NONE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	notnull(t->msg_bad);
+	require(streq(t->msg_bad, "A small dart hits you!  Numbness spreads "
+		"from where it pricked you."));
+	ok;
+}
+
+static int test_msg_xtra0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r = parser_parse(p, "msg-xtra:You are impaled!");
+	struct trap_kind *t;
+
+	eq(r, PARSE_ERROR_NONE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	notnull(t->msg_xtra);
+	require(streq(t->msg_xtra, "You are impaled!"));
+	/* Check that a second directive is appended to the first. */
+	r = parser_parse(p, "msg-xtra:  And begin to bleed profusely.");
+	eq(r, PARSE_ERROR_NONE);
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	notnull(t->msg_xtra);
+	require(streq(t->msg_xtra, "You are impaled!  And begin to bleed "
+		"profusely."));
+	ok;
+}
+
+static int test_complete0(void *state) {
+	const char *lines[] = {
+		"name:dart trap:slow dart",
+		"graphics:^:r",
+		"rarity:1",
+		"min-depth:2",
+		"max-depth:15",
+		"stealth:-1",
+		"flags:TRAP | FLOOR | SURFACE",
+		"effect:DAMAGE",
+		"dice:1d4",
+		"effect:TIMED_INC_NO_RES:SLOW",
+		"dice:20+1d20",
+		"desc:A trap which shoots slowing darts.",
+		"msg-good:A small dart barely misses you.",
+		"msg-bad:A small dart hits you!"
+	};
+	struct parser *p = (struct parser*) state;
+	bitflag tflags[TRF_SIZE];
+	struct trap_kind *t;
+	struct effect *e;
+	int i;
+
+	for (i = 0; i < (int) N_ELEMENTS(lines); ++i) {
+		enum parser_error r = parser_parse(p, lines[i]);
+
+		eq(r, PARSE_ERROR_NONE);
+	}
+	t = (struct trap_kind*) parser_priv(p);
+	notnull(t);
+	notnull(t->name);
+	require(streq(t->name, "dart trap"));
+	notnull(t->desc);
+	require(streq(t->desc, "slow dart"));
+	null(t->msg);
+	null(t->msg2);
+	null(t->msg3);
+	null(t->msg_vis);
+	null(t->msg_silence);
+	notnull(t->msg_good);
+	require(streq(t->msg_good, "A small dart barely misses you."));
+	notnull(t->msg_bad);
+	require(streq(t->msg_bad, "A small dart hits you!"));
+	null(t->msg_xtra);
+	eq(t->d_attr, COLOUR_RED);
+	eq(t->d_char, L'^');
+	eq(t->rarity, 1);
+	eq(t->min_depth, 2);
+	eq(t->max_depth, 15);
+	eq(t->power, 0);
+	eq(t->stealth, -1);
+	trf_wipe(tflags);
+	trf_on(tflags, TRF_TRAP);
+	trf_on(tflags, TRF_FLOOR);
+	trf_on(tflags, TRF_SURFACE);
+	require(trf_is_equal(t->flags, tflags));
+	e = t->effect;
+	notnull(e);
+	eq(e->index, EF_DAMAGE);
+	notnull(e->dice);
+	require(dice_test_values(e->dice, 0, 1, 4, 0));
+	eq(e->subtype, 0);
+	eq(e->radius, 0);
+	eq(e->other, 0);
+	null(e->msg);
+	e = e->next;
+	notnull(e);
+	eq(e->index, EF_TIMED_INC_NO_RES);
+	notnull(e->dice);
+	require(dice_test_values(e->dice, 20, 1, 20, 0));
+	eq(e->subtype, TMD_SLOW);
+	eq(e->radius, 0);
+	eq(e->other, 0);
+	null(e->msg);
+	e = e->next;
+	null(e);
+	null(t->effect_xtra);
+	ok;
+}
+
+const char *suite_name = "parse/partrap";
+/*
+ * test_missing_header_record0() has to be before test_name0() and
+ * test_complete0().
+ * test_missing_effect0() has to be after test_name0() and before
+ * test_effect0(), test_effect_bad0(), test_dice0(), test_dice_bad0(),
+ * test_missing_dice0(), test_expr0(), test_expr_bad0(), and test_complete0().
+ * test_missing_effect_xtra0() has to be after test_name0() and before
+ * test_effect_xtra0(), test_effect_xtra_bad0(), test_dice_xtra0(),
+ * test_dice_xtra_bad0(), test_missing_dice_xtra0(),
+ * test_expr_xtra0(), test_expr_xtra_bad0(), and test_complete0().
+ * Unless otherwise indicated, all other functions have to be after
+ * test_name0().
+ */
+struct test tests[] = {
+	{ "missing_header_record0", test_missing_header_record0 },
+	{ "name0", test_name0 },
+	{ "graphics0", test_graphics0 },
+	{ "rarity0", test_rarity0 },
+	{ "min_depth0", test_min_depth0 },
+	{ "max_depth0", test_max_depth0 },
+	{ "power0", test_power0 },
+	{ "power_bad0", test_power_bad0 },
+	{ "stealth0", test_stealth0 },
+	{ "flags0", test_flags0 },
+	{ "flags_bad0", test_flags_bad0 },
+	{ "missing_effect0", test_missing_effect0 },
+	{ "effect0", test_effect0 },
+	{ "effect_bad0", test_effect_bad0 },
+	{ "dice0", test_dice0 },
+	{ "dice_bad0", test_dice_bad0 },
+	{ "missing_dice0", test_missing_dice0 },
+	{ "expr0", test_expr0 },
+	{ "expr_bad0", test_expr_bad0 },
+	{ "missing_effect_xtra0", test_missing_effect_xtra0 },
+	{ "effect_xtra0", test_effect_xtra0 },
+	{ "effect_xtra_bad0", test_effect_xtra_bad0 },
+	{ "dice_xtra0", test_dice_xtra0 },
+	{ "dice_xtra_bad0", test_dice_xtra_bad0 },
+	{ "missing_dice_xtra0", test_missing_dice_xtra0 },
+	{ "expr_xtra0", test_expr_xtra0 },
+	{ "expr_xtra_bad0", test_expr_xtra_bad0 },
+	{ "desc0", test_desc0 },
+	{ "msg0", test_msg0 },
+	{ "msg2_0", test_msg2_0 },
+	{ "msg3_0", test_msg3_0 },
+	{ "msg_vis0", test_msg_vis0 },
+	{ "msg_silence0", test_msg_silence0 },
+	{ "msg_good0", test_msg_good0 },
+	{ "msg_bad0", test_msg_bad0 },
+	{ "msg_xtra0", test_msg_xtra0 },
+	{ "complete0", test_complete0 },
+	{ NULL, NULL }
+};

--- a/src/tests/parse/sex-info.c
+++ b/src/tests/parse/sex-info.c
@@ -1,0 +1,137 @@
+/* parse/sex-info */
+/* Exercise parsing used for sex.txt. */
+
+#include "unit-test.h"
+#include "init.h"
+#include "player.h"
+
+int setup_tests(void **state) {
+	*state = sex_parser.init();
+	return !*state;
+}
+
+int teardown_tests(void *state) {
+	struct parser *p = (struct parser*) state;
+	int r = 0;
+
+	if (sex_parser.finish(p)) {
+		r = 1;
+	}
+	sex_parser.cleanup();
+	return r;
+}
+
+static int test_missing_header_record0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r;
+
+	null(parser_priv(p));
+	r = parser_parse(p, "possess:her");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "poetry:female_entry_poetry");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	ok;
+}
+
+static int test_name0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r = parser_parse(p, "name:Female");
+	struct player_sex *s;
+
+	eq(r, PARSE_ERROR_NONE);
+	s = (struct player_sex*) parser_priv(p);
+	notnull(s);
+	notnull(s->name);
+	require(streq(s->name, "Female"));
+	null(s->possessive);
+	null(s->poetry_name);
+	ok;
+}
+
+static int test_possessive0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r = parser_parse(p, "possess:her");
+	struct player_sex *s;
+
+	eq(r, PARSE_ERROR_NONE);
+	s = (struct player_sex*) parser_priv(p);
+	notnull(s);
+	notnull(s->possessive);
+	require(streq(s->possessive, "her"));
+	/*
+	 * Specifying multiple times for the same sex should not leak
+	 * memory.
+	 */
+	r = parser_parse(p, "possess:his");
+	eq(r, PARSE_ERROR_NONE);
+	s = (struct player_sex*) parser_priv(p);
+	notnull(s);
+	notnull(s->possessive);
+	require(streq(s->possessive, "his"));
+	ok;
+}
+
+static int test_poetry0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r = parser_parse(p, "poetry:female_entry_poetry");
+	struct player_sex *s;
+
+	eq(r, PARSE_ERROR_NONE);
+	s = (struct player_sex*) parser_priv(p);
+	notnull(s);
+	notnull(s->poetry_name);
+	require(streq(s->poetry_name, "female_entry_poetry"));
+	/*
+	 * Specifying multiple times for the same sex should not leak
+	 * memory.
+	 */
+	r = parser_parse(p, "poetry:male_entry_poetry");
+	eq(r, PARSE_ERROR_NONE);
+	s = (struct player_sex*) parser_priv(p);
+	notnull(s);
+	notnull(s->poetry_name);
+	require(streq(s->poetry_name, "male_entry_poetry"));
+	ok;
+}
+
+static int test_complete0(void *state) {
+	const char *lines[] = {
+		"name:Male",
+		"possess:his",
+		"poetry:male_entry_poetry"
+	};
+	struct parser *p = (struct parser*) state;
+	struct player_sex *s;
+	int i;
+
+	for (i = 0; i < (int) N_ELEMENTS(lines); ++i) {
+		enum parser_error r = parser_parse(p, lines[i]);
+
+		eq(r, PARSE_ERROR_NONE);
+	}
+	s = (struct player_sex*) parser_priv(p);
+	notnull(s);
+	notnull(s->name);
+	require(streq(s->name, "Male"));
+	notnull(s->possessive);
+	require(streq(s->possessive, "his"));
+	notnull(s->poetry_name);
+	require(streq(s->poetry_name, "male_entry_poetry"));
+	ok;
+}
+
+const char *suite_name = "parse/parsex";
+/*
+ * test_missing_header_record0() has to be before test_name0() and
+ * test_complete0().
+ * Unless otherwise indicated, all other functions have to be after
+ * test_name0().
+ */
+struct test tests[] = {
+	{ "missing_header_record0", test_missing_header_record0 },
+	{ "name0", test_name0 },
+	{ "possessive0", test_possessive0 },
+	{ "poetry0", test_poetry0 },
+	{ "complete0", test_complete0 },
+	{ NULL, NULL }
+};

--- a/src/tests/parse/suite.mk
+++ b/src/tests/parse/suite.mk
@@ -1,6 +1,7 @@
 TESTPROGS += parse/a-info \
 	parse/blowe \
 	parse/blowm \
+	parse/body \
 	parse/e-info \
 	parse/f-info \
 	parse/flavor \
@@ -12,6 +13,9 @@ TESTPROGS += parse/a-info \
 	parse/names \
 	parse/p-info \
 	parse/parse \
+	parse/partrap \
 	parse/r-info \
+	parse/sex-info \
 	parse/v-info \
+	parse/world \
 	parse/z-info

--- a/src/tests/parse/world.c
+++ b/src/tests/parse/world.c
@@ -1,0 +1,67 @@
+/* parse/world */
+/* Exercise parsing used for world.txt. */
+
+#include "unit-test.h"
+#include "game-world.h"
+#include "init.h"
+
+NOSETUP
+NOTEARDOWN
+
+static int test_complete0(void *state)
+{
+	const char *lines[] = {
+		"level:0:Town:None:Test 1",
+		"level:1:Test 1:Town:Test 2",
+		"level:2:Test 2:Test 1:None"
+	};
+	struct parser *p = world_parser.init();
+	struct level *lv;
+	int i, rtn;
+
+	notnull(p);
+	for (i = 0; i < (int) N_ELEMENTS(lines); ++i) {
+		enum parser_error r = parser_parse(p, lines[i]);
+
+		eq(r, PARSE_ERROR_NONE);
+	}
+	rtn = world_parser.finish(p);
+	eq(rtn, 0);
+
+	lv = world;
+	notnull(lv);
+	eq(lv->depth, 0);
+	notnull(lv->name);
+	require(streq(lv->name, "Town"));
+	null(lv->up);
+	notnull(lv->down);
+	require(streq(lv->down, "Test 1"));
+	lv = lv->next;
+	notnull(lv);
+	eq(lv->depth, 1);
+	notnull(lv->name);
+	require(streq(lv->name, "Test 1"));
+	notnull(lv->up);
+	require(streq(lv->up, "Town"));
+	notnull(lv->down);
+	require(streq(lv->down, "Test 2"));
+	lv = lv->next;
+	notnull(lv);
+	eq(lv->depth, 2);
+	notnull(lv->name);
+	require(streq(lv->name, "Test 2"));
+	notnull(lv->up);
+	require(streq(lv->up, "Test 1"));
+	null(lv->down);
+	lv = lv->next;
+	null(lv);
+
+	world_parser.cleanup();
+	ok;
+}
+
+const char *suite_name = "parse/world";
+struct test tests[] = {
+	{ "complete0", test_complete0 },
+	{ NULL, NULL }
+};

--- a/src/tests/parse/z-info.c
+++ b/src/tests/parse/z-info.c
@@ -1,4 +1,5 @@
 /* parse/z-info */
+/* Exercise parsing used for constants.txt. */
 
 #include "unit-test.h"
 #include "unit-test-data.h"
@@ -7,7 +8,7 @@
 
 
 int setup_tests(void **state) {
-	*state = init_parse_constants();
+	*state = constants_parser.init();
 	return !*state;
 }
 
@@ -19,58 +20,150 @@ int teardown_tests(void *state) {
 }
 
 static int test_negative(void *state) {
-	errr r = parser_parse(state, "level-max:F:-1");
+	struct parser *p = (struct parser*) state;
+	errr r = parser_parse(p, "level-max:monsters:-1");
+
+	eq(r, PARSE_ERROR_INVALID_VALUE);
+	r = parser_parse(p, "mon-gen:change:-1");
+	eq(r, PARSE_ERROR_INVALID_VALUE);
+	r = parser_parse(p, "mon-play:mult-rate:-1");
+	eq(r, PARSE_ERROR_INVALID_VALUE);
+	r = parser_parse(p, "dun-gen:room-max:-1");
+	eq(r, PARSE_ERROR_INVALID_VALUE);
+	r = parser_parse(p, "world:dungeon-hgt:-1");
+	eq(r, PARSE_ERROR_INVALID_VALUE);
+	r = parser_parse(p, "carry-cap:pack-size:-1");
+	eq(r, PARSE_ERROR_INVALID_VALUE);
+	r = parser_parse(p, "obj-make:great-obj:-1");
+	eq(r, PARSE_ERROR_INVALID_VALUE);
+	r = parser_parse(p, "player:max-sight:-1");
 	eq(r, PARSE_ERROR_INVALID_VALUE);
 	ok;
 }
 
-static int test_badmax(void *state) {
+static int test_baddirective(void *state) {
+	struct parser *p = (struct parser*) state;
 	errr r = parser_parse(state, "level-max:D:1");
+
+	eq(r, PARSE_ERROR_UNDEFINED_DIRECTIVE);
+	r = parser_parse(p, "mon-gen:xyzzy:5");
+	eq(r, PARSE_ERROR_UNDEFINED_DIRECTIVE);
+	r = parser_parse(p, "mon-play:xyzzy:10");
+	eq(r, PARSE_ERROR_UNDEFINED_DIRECTIVE);
+	r = parser_parse(p, "dun-gen:xyzzy:3");
+	eq(r, PARSE_ERROR_UNDEFINED_DIRECTIVE);
+	r = parser_parse(p, "world:xyzzy:170");
+	eq(r, PARSE_ERROR_UNDEFINED_DIRECTIVE);
+	r = parser_parse(p, "carry-cap:xyzzy:40");
+	eq(r, PARSE_ERROR_UNDEFINED_DIRECTIVE);
+	r = parser_parse(p, "obj-make:xyzzy:5000");
+	eq(r, PARSE_ERROR_UNDEFINED_DIRECTIVE);
+	r = parser_parse(p, "player:xyzzy:300");
 	eq(r, PARSE_ERROR_UNDEFINED_DIRECTIVE);
 	ok;
 }
 
-#define TEST_MAX(l,u) \
+#define TEST_CONSTANT(l,u,section) \
 	static int test_##l(void *s) { \
 		struct angband_constants *m = parser_priv(s); \
 		char buf[64]; \
 		errr r; \
-		snprintf(buf, sizeof(buf), "level-max:%s:%d", u, __LINE__); \
+		snprintf(buf, sizeof(buf), "%s:%s:%d", section, u, __LINE__); \
 		r = parser_parse(s, buf); \
 		eq(m->l, __LINE__); \
 		eq(r, 0); \
 		ok; \
 	}
 
-TEST_MAX(level_monster_max, "monsters")
+TEST_CONSTANT(level_monster_max, "monsters", "level-max")
 
-#define TEST_MON(l,u) \
-	static int test_##l(void *s) { \
-		struct angband_constants *m = parser_priv(s); \
-		char buf[64]; \
-		errr r; \
-		snprintf(buf, sizeof(buf), "mon-gen:%s:%d", u, __LINE__); \
-		r = parser_parse(s, buf); \
-		eq(m->l, __LINE__); \
-		eq(r, 0); \
-		ok; \
-	}
+TEST_CONSTANT(alloc_monster_chance, "chance", "mon-gen")
+TEST_CONSTANT(monster_group_max, "group-max", "mon-gen")
 
-TEST_MON(alloc_monster_chance, "chance")
-TEST_MON(level_monster_min, "level-min")
-TEST_MON(town_monsters_day, "town-day")
-TEST_MON(town_monsters_night, "town-night")
-TEST_MON(repro_monster_max, "repro-max")
+TEST_CONSTANT(repro_monster_rate, "mult-rate", "mon-play")
+TEST_CONSTANT(mana_cost, "mana-cost", "mon-play")
+TEST_CONSTANT(mana_max, "mana-max", "mon-play")
+TEST_CONSTANT(flee_range, "flee-range", "mon-play")
+TEST_CONSTANT(turn_range, "turn-range", "mon-play")
+TEST_CONSTANT(hide_range, "hide-range", "mon-play")
+TEST_CONSTANT(wander_range, "wander-range", "mon-play")
+TEST_CONSTANT(mon_regen_hp_period, "regen-hp-period", "mon-play")
+TEST_CONSTANT(mon_regen_sp_period, "regen-sp-period", "mon-play")
+
+TEST_CONSTANT(level_room_max, "room-max", "dun-gen")
+TEST_CONSTANT(level_room_min, "room-min", "dun-gen")
+TEST_CONSTANT(block_hgt, "block-hgt", "dun-gen")
+TEST_CONSTANT(block_wid, "block-wid", "dun-gen")
+
+TEST_CONSTANT(dun_depth, "dun-depth", "world")
+TEST_CONSTANT(max_depth, "max-depth", "world")
+TEST_CONSTANT(day_length, "day-length", "world")
+TEST_CONSTANT(dungeon_hgt, "dungeon-hgt", "world")
+TEST_CONSTANT(dungeon_wid, "dungeon-wid", "world")
+TEST_CONSTANT(move_energy, "move-energy", "world")
+TEST_CONSTANT(flow_max, "flow-max", "world")
+
+TEST_CONSTANT(pack_size, "pack-size", "carry-cap")
+TEST_CONSTANT(floor_size, "floor-size", "carry-cap")
+
+TEST_CONSTANT(max_obj_depth, "max-depth", "obj-make")
+TEST_CONSTANT(great_obj, "great-obj", "obj-make")
+TEST_CONSTANT(great_ego, "great-spec", "obj-make")
+TEST_CONSTANT(default_torch, "default-torch", "obj-make")
+TEST_CONSTANT(fuel_torch, "fuel-torch", "obj-make")
+TEST_CONSTANT(default_lamp, "default-lamp", "obj-make")
+TEST_CONSTANT(fuel_lamp, "fuel-lamp", "obj-make")
+TEST_CONSTANT(self_arts_max, "self-arts", "obj-make")
+
+TEST_CONSTANT(max_sight, "max-sight", "player")
+TEST_CONSTANT(max_range, "max-range", "player")
+TEST_CONSTANT(start_exp, "start-exp", "player")
+TEST_CONSTANT(ability_cost, "ability-cost", "player")
+TEST_CONSTANT(stealth_bonus, "stealth-bonus", "player")
+TEST_CONSTANT(player_regen_period, "regen-period", "player")
 
 const char *suite_name = "parse/z-info";
 struct test tests[] = {
 	{ "negative", test_negative },
-	{ "badmax", test_badmax },
+	{ "baddirective", test_baddirective },
 	{ "monsters_max", test_level_monster_max },
 	{ "mon_chance", test_alloc_monster_chance },
-	{ "monsters_min", test_level_monster_min },
-	{ "town_day", test_town_monsters_day },
-	{ "town_night", test_town_monsters_night },
-	{ "repro_max", test_repro_monster_max },
+	{ "group_max", test_monster_group_max },
+	{ "mult_rate", test_repro_monster_rate },
+	{ "mana_cost", test_mana_cost },
+	{ "mana_max", test_mana_max },
+	{ "flee_range", test_flee_range },
+	{ "turn_range", test_turn_range },
+	{ "hide_range", test_hide_range },
+	{ "wander_range", test_wander_range },
+	{ "mon_regen_hp_period", test_mon_regen_hp_period },
+	{ "mon_regen_sp_period", test_mon_regen_sp_period },
+	{ "room_max", test_level_room_max },
+	{ "room_min", test_level_room_min },
+	{ "block_hgt", test_block_hgt },
+	{ "block_wid", test_block_wid },
+	{ "dun_depth", test_dun_depth },
+	{ "max_depth", test_max_depth },
+	{ "day_length", test_day_length },
+	{ "dungeon_hgt", test_dungeon_hgt },
+	{ "dungeon_wid", test_dungeon_wid },
+	{ "move_energy", test_move_energy },
+	{ "flow_max", test_flow_max },
+	{ "pack_size", test_pack_size },
+	{ "floor_size", test_floor_size },
+	{ "max_obj_depth", test_max_obj_depth },
+	{ "great_obj", test_great_obj },
+	{ "great_ego", test_great_ego },
+	{ "default_torch", test_default_torch },
+	{ "fuel_torch", test_fuel_torch },
+	{ "fuel_lamp", test_fuel_lamp },
+	{ "default_lamp", test_default_lamp },
+	{ "self_arts_max", test_self_arts_max },
+	{ "max_sight", test_max_sight },
+	{ "max_range", test_max_range },
+	{ "start_exp", test_start_exp },
+	{ "ability_cost", test_ability_cost },
+	{ "stealth_bonus", test_stealth_bonus },
+	{ "player_regen_period", test_player_regen_period },
 	{ NULL, NULL }
 };

--- a/src/trap.c
+++ b/src/trap.c
@@ -436,7 +436,7 @@ static enum parser_error parse_trap_msg_xtra(struct parser *p) {
     return PARSE_ERROR_NONE;
 }
 
-struct parser *init_parse_trap(void) {
+static struct parser *init_parse_trap(void) {
     struct parser *p = parser_new();
     parser_setpriv(p, NULL);
     parser_reg(p, "name sym name str desc", parse_trap_name);


### PR DESCRIPTION
Remove vestigial constants left over from Vanilla Angband.  Plug possibility of memory leaks if some directives in house.txt or sex.txt appear more than once in a record.