### PR TITLE
Get parsing of monster.txt as lore.txt to work.

### DIFF
--- a/src/mon-init.c
+++ b/src/mon-init.c
@@ -2227,9 +2227,6 @@ static enum parser_error parse_lore_drop(struct parser *p) {
 	if (sval < 0)
 		return PARSE_ERROR_UNRECOGNISED_SVAL;
 
-	if (parser_getuint(p, "min") > 99 || parser_getuint(p, "max") > 99)
-		return PARSE_ERROR_INVALID_ITEM_NUMBER;
-
 	k = lookup_kind(tval, sval);
 	if (!k)
 		return PARSE_ERROR_UNRECOGNISED_SVAL;
@@ -2290,7 +2287,7 @@ static struct parser *init_parse_lore(void) {
 	parser_reg(p, "spells str spells", parse_lore_spells);
 	parser_reg(p, "message-vis sym spell ?str message", ignored);
 	parser_reg(p, "message-invis sym spell ?str message", ignored);
-	parser_reg(p, "drop sym tval sym sval uint chance uint min uint max", parse_lore_drop);
+	parser_reg(p, "drop sym tval sym sval uint chance rand dice", parse_lore_drop);
 	parser_reg(p, "drop-artifact str name", parse_lore_drop_artifact);
 	parser_reg(p, "color-cycle sym group sym cycle", ignored);
 	return p;

--- a/src/tests/parse/lore.c
+++ b/src/tests/parse/lore.c
@@ -23,16 +23,17 @@ static errr run_parse_monster(struct parser *p) {
 	return parse_file(p, "monster");
 }
 
+static errr finish_parse_monster(struct parser *p) {
+	return 0;
+}
+
 static int test_lore_parse_monster_text(void *state) {
+	struct file_parser test_lore_parser = lore_parser;
+	errr err;
 
-	struct file_parser test_lore_perser = lore_parser;
-	test_lore_perser.run = run_parse_monster;
-
-	ok;
-	/* Leaving this out for now because it's leading to double frees due to
-	 * calling finish_parse_lore() after run_parse_monster() instead of
-	 * run_parse_lore() */
-	errr err = run_parser(&test_lore_perser);
+	test_lore_parser.run = run_parse_monster;
+	test_lore_parser.finish = finish_parse_monster;
+	err = run_parser(&test_lore_parser);
 
 	eq(err, PARSE_ERROR_NONE);
 
@@ -40,7 +41,7 @@ static int test_lore_parse_monster_text(void *state) {
 }
 
 
-const char *suite_name = "parse/lure";
+const char *suite_name = "parse/lore";
 struct test tests[] = {
 	{ "lore_parse_monster_text", test_lore_parse_monster_text },
 	{ NULL, NULL }


### PR DESCRIPTION
Port Vanilla Angband's changes to reenable test to parse monster.txt with the monster lore parser.