### PR TITLE
Effect selection menu: only add the random option if requested

### DIFF
--- a/src/ui-effect.c
+++ b/src/ui-effect.c
@@ -30,7 +30,7 @@
  * the menu failed
  */
 static struct menu *effect_menu_new(struct effect *effect, int count,
-	bool allow_random)
+		bool allow_random)
 {
 	struct menu *m = menu_new(MN_SKIN_SCROLL,
 		menu_find_iter(MN_ITER_STRINGS));
@@ -50,10 +50,13 @@ static struct menu *effect_menu_new(struct effect *effect, int count,
 		 * effect_menu_destroy().
 		 */
 		ms = mem_alloc((count + 1) * sizeof(*ms));
-		ms[ms_count] = string_make("one of the following at random");
-		width = MAX(width,
-			(int)MIN(strlen(ms[ms_count]) + 3, (size_t)(Term->wid)));
-		++ms_count;
+		if (allow_random) {
+			ms[ms_count] =
+				string_make("one of the following at random");
+			width = MAX(width, (int)MIN(strlen(ms[ms_count])
+				+ 3, (size_t)(Term->wid)));
+			++ms_count;
+		}
 	} else {
 		ms = NULL;
 	}


### PR DESCRIPTION
In the current code, the random option is always requested so the player will not see a change in how the menu behaves.