### PR TITLE
Generalize handling of ^

### DIFF
--- a/src/ui-input.c
+++ b/src/ui-input.c
@@ -1772,10 +1772,16 @@ ui_event textui_get_command(int *count)
 				}
 
 				case '^': {
-					char ch;
 					/* Allow "control chars" to be entered */
-					if (get_com("Control: ", &ch))
-						ke.key.code = KTRL(ch);
+					if (!get_com_ex("Control: ", &ke)
+							|| ke.type != EVT_KBRD) {
+						continue;
+					}
+					if (ENCODE_KTRL(ke.key.code)) {
+						ke.key.code = KTRL(ke.key.code);
+					} else {
+						ke.key.mods |= KC_MOD_CONTROL;
+					}
 					break;
 				}
 			}


### PR DESCRIPTION
1) Use get_com_ex() rather than get_com() so the argument for ^ is not coerced to a char. 2) Only use KTRL() to encode the keystroke if ENCODE_KTRL() for the argument to ^ is true; otherwise put KC_MOD_CONTROL in the modifiers.

Resolves https://github.com/angband/angband/issues/5748 .