### PR TITLE
Update narsil-sdl2.desktop

### DIFF
--- a/lib/icons/narsil-sdl2.desktop
+++ b/lib/icons/narsil-sdl2.desktop
@@ -2,7 +2,7 @@
 Name=NarSil (SDL2)
 Type=Application
 Comment=A roguelike dungeon exploration game based on the books of J.R.R.Tolkien
-Exec=sh -c "if [ \\$XDG_SESSION_TYPE == \"wayland\" ]; then env SDL_VIDEODRIVER=wayland narsil -msdl2; else narsil -msdl2; fi"
+Exec=narsil -msdl2
 TryExec=narsil
 Icon=narsil
 Categories=Game;RolePlaying;


### PR DESCRIPTION
Fix added in #5302 not required anymore since SDL currently prioritizes wayland over x11.

https://github.com/libsdl-org/SDL/pull/4306/files