### PR TITLE
SDL2: display quit message to the screen

### DIFF
--- a/src/main-sdl2.c
+++ b/src/main-sdl2.c
@@ -6042,7 +6042,18 @@ static void quit_systems(void)
 
 static void quit_hook(const char *s)
 {
-	dump_config_file();
+	if (s) {
+		SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, "Fatal Error",
+			s, NULL);
+	}
+
+	/*
+	 * If at least the main window was successfully set up, remember the
+	 * configuration.
+	 */
+	if (g_windows[0].loaded) {
+		dump_config_file();
+	}
 
 	free_globals();
 	quit_systems();
@@ -6078,12 +6089,13 @@ static void init_systems(void)
 
 errr init_sdl2(int argc, char **argv)
 {
+	quit_aux = quit_hook;
+
 	init_systems();
 	init_globals();
 
 	if (!init_graphics_modes()) {
-		quit_systems();
-		return 1;
+		quit("Graphics list load failed");
 	}
 
 	if (!read_config_file()) {
@@ -6114,8 +6126,6 @@ errr init_sdl2(int argc, char **argv)
 	text_iswprint_hook = term_iswprint_sdl2_msys2;
 #endif /* MSYS2_ENCODING_WORKAROUND */
 
-	quit_aux = quit_hook;
-
 	return 0;
 }
 
@@ -6125,6 +6135,9 @@ static char g_config_file[4096];
 
 static void init_globals(void)
 {
+	path_build(g_config_file, sizeof(g_config_file),
+			DEFAULT_CONFIG_FILE_DIR, DEFAULT_CONFIG_FILE);
+
 	for (size_t i = 0; i < N_ELEMENTS(g_subwindows); i++) {
 		g_subwindows[i].index = i;
 	}
@@ -6134,9 +6147,6 @@ static void init_globals(void)
 
 	init_font_info(ANGBAND_DIR_FONTS);
 	init_colors();
-
-	path_build(g_config_file, sizeof(g_config_file),
-			DEFAULT_CONFIG_FILE_DIR, DEFAULT_CONFIG_FILE);
 }
 
 static bool is_subwindow_loaded(unsigned index)


### PR DESCRIPTION
Allows for better diagnostics if run from a desktop file or other situations where the user can not see what is written to standard error.