### PR TITLE
configure: remove skip-old-int-typedefs option (#5524)

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Build
         run: |
           ./autogen.sh
-          ./configure --with-no-install --enable-test --enable-skip-old-int-typedefs
+          ./configure --with-no-install --enable-test
           make
           make tests
           ./run-tests
@@ -98,7 +98,7 @@ jobs:
       - name: Build
         run: |
           ./autogen.sh
-          ./configure --with-no-install --enable-sdl2 --enable-sdl2-mixer --enable-skip-old-int-typedefs
+          ./configure --with-no-install --enable-sdl2 --enable-sdl2-mixer
           make
 
   statbuild:
@@ -118,7 +118,7 @@ jobs:
       - name: Build
         run: |
           ./autogen.sh
-          env CFLAGS="-Wvla -Wlogical-op" ./configure --with-no-install --enable-stats --enable-test --enable-sdl-mixer --enable-skip-old-int-typedefs
+          env CFLAGS="-Wvla -Wlogical-op" ./configure --with-no-install --enable-stats --enable-test --enable-sdl-mixer
           make
 
   makefilestd:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -246,7 +246,7 @@ jobs:
         id: create_windows_archive
         run: |
           ./autogen.sh
-          env CFLAGS="-O2" ./configure --enable-release --enable-win --build=i686-pc-linux-gnu --host=i686-w64-mingw32 --enable-skip-old-int-typedefs
+          env CFLAGS="-O2" ./configure --enable-release --enable-win --build=i686-pc-linux-gnu --host=i686-w64-mingw32
           make
           cp src/${{ steps.store_config.outputs.prog }}.exe src/win/dll/libpng12.dll src/win/dll/zlib1.dll .
           archive_prefix=${{ steps.store_config.outputs.name }}-${{ steps.store_config.outputs.version }}
@@ -312,13 +312,12 @@ jobs:
       # Makefile.osx is overridden.  If the default SDK does not handle that,
       # setting SDKROOT to point to an installed SDK that does would be one
       # workaround.  Override the default OPT (-O2) to get the equivalent of
-      # what --enable-release and --enable-skip-old-int-typedefs does for
-      # builds using configure.
+      # what --enable-release does for builds using configure.
       - name: Create Mac Archive
         id: create_mac_archive
         run: |
           cd src
-          env OPT="-O2 -DNDEBUG -DSKIP_ANGBAND_OLD_INT_TYPEDEFS" make -f Makefile.osx dist
+          env OPT="-O2 -DNDEBUG" make -f Makefile.osx dist
           archive_prefix=${{ steps.store_config.outputs.name }}-${{ steps.store_config.outputs.version }}-osx
           echo "archive_file=${archive_prefix}.dmg" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -21,6 +21,6 @@ jobs:
       - name: Build
         run: |
           ./autogen.sh
-          ./configure --enable-win --build=i686-pc-linux-gnu --host=i686-w64-mingw32 --enable-skip-old-int-typedefs
+          ./configure --enable-win --build=i686-pc-linux-gnu --host=i686-w64-mingw32
           make
 

--- a/configure.ac
+++ b/configure.ac
@@ -130,18 +130,6 @@ if test "$GCC" = "yes"; then
 	CFLAGS="$CFLAGS -Wnested-externs -Wshadow"
 fi
 
-AC_ARG_ENABLE(skip-old-int-typedefs,
-	[AS_HELP_STRING([--enable-skip-old-int-typedefs], [do not generate the u32b, s32b, ... typedefs in Angband's headers])],
-	[AS_CASE(${enableval},
-		[yes], [skip_old_int_typedefs=yes],
-		[no], [skip_old_int_typedefs=no],
-		[AC_MSG_ERROR([bad value ${enableval} for --enable-skip-old-int-typedefs])])],
-	[skip_old_int_typedefs=no])
-
-if test x"$skip_old_int_typedefs" = xyes ; then
-	AC_DEFINE(SKIP_ANGBAND_OLD_INT_TYPEDEFS, 1, [Define to skip generating the u32b, s32b, ... typedefs])
-fi
-
 MY_PROG_MAKE_SYSVINC
 MY_PROG_MAKE_SINCLUDE
 

--- a/docs/hacking/compiling.rst
+++ b/docs/hacking/compiling.rst
@@ -300,8 +300,7 @@ process to fail when linking angband.exe (the error message will likely be
 "cannot find -lncursesw" and "cannot find -ltinfo").  Most of the --with or
 --enable options for configure are not appropriate when using --enable-win.
 The ones that are okay are --with-private-dirs (on by default),
---with-gamedata-in-lib (has no effect), --enable-release,
---enable-more-gcc-warnings, and --enable-skip-old-int-typedefs.
+--with-gamedata-in-lib (has no effect), and --enable-release.
 
 Debug build
 ~~~~~~~~~~~

--- a/src/h-basic.h
+++ b/src/h-basic.h
@@ -135,31 +135,9 @@
 
 /**
  * errr is an error code
- *
- * byte/s16b/u16b/s32b/u32b/s64b/u64b have been deprecated; use the
- * standard uint8_t, int16_t, uint16_t, ... types instead.  Those typedefs
- * will still be defined if SKIP_ANGBAND_OLD_INT_TYPEDEFS is not set.
- *
- * A "byte" is an unsigned byte of memory.
- * s16b/u16b are exactly 2 bytes (where possible)
- * s32b/u32b are exactly 4 bytes (where possible)
  */
 
 typedef int errr;
-
-#ifndef SKIP_ANGBAND_OLD_INT_TYPEDEFS
-/* Use guaranteed-size types */
-typedef uint8_t byte;
-
-typedef uint16_t u16b;
-typedef int16_t s16b;
-
-typedef uint32_t u32b;
-typedef int32_t s32b;
-
-typedef uint64_t u64b;
-typedef int64_t s64b;
-#endif
 
 /** Debugging macros ***/
 


### PR DESCRIPTION
These typedefs aren't used anywhere in the source and it's hard to conceive of a situation where one would want to enable them, given that they have been fully replaced with standard C types.