### PR TITLE
Port Vanilla Angband's additions to dependencies for SDL2 on MSYS2

### DIFF
--- a/src/Makefile.msys2.sdl2
+++ b/src/Makefile.msys2.sdl2
@@ -32,9 +32,12 @@
 default: install
 
 # Support SDL2 frontend, link all dependencies statically
-# freetype and harfbuzz has Circular dependency
-VIDEO_sdl2 := -DUSE_SDL2 \
+# freetype and harfbuzz have circular dependency
+VIDEO_sdl2_cflags := \
+	-DUSE_SDL2 \
 	$(shell sdl2-config --cflags) \
+
+VIDEO_sdl2_ldflags := \
 	$(shell sdl2-config --static-libs) \
 	-lSDL2_ttf -lSDL2_image \
 	-ltiff \
@@ -44,7 +47,14 @@ VIDEO_sdl2 := -DUSE_SDL2 \
 	-llzma \
 	-ljxl \
 	-lhwy \
+	-lavif \
+	-laom \
+	-ldav1d \
+	-lrav1e \
+	-lSvtAv1Enc \
+	-lyuv \
 	-lwebp \
+	-lwebpdemux \
 	-lsharpyuv \
 	-lfreetype \
 	-lharfbuzz \
@@ -68,18 +78,25 @@ VIDEO_sdl2 := -DUSE_SDL2 \
 	-lole32 \
 	-loleaut32 \
 	-lwinmm \
+	-lntdll
 
 ## Support SDL_mixer for sound
 ifdef SOUND
-SOUND_sdl2 := -DSOUND_SDL2 -DSOUND \
+SOUND_sdl2_cflags := \
+	-DSOUND_SDL2 \
+	-DSOUND \
 	$(shell sdl2-config --cflags) \
-	$(shell sdl2-config --libs) -lSDL2_mixer \
+
+SOUND_sdl2_ldflags := \
+	$(shell sdl2-config --libs) \
+	-lSDL2_mixer \
 	-lmpg123 \
 	-lopusfile \
 	-lopus \
 	-logg \
 	-lshlwapi \
 	-lwinmm
+
 endif
 
 # Compiler to use
@@ -103,14 +120,15 @@ CFLAGS := -std=c99 \
 LDFLAGS :=
 
 # Frontends to compile
-MODULES := $(VIDEO_sdl2)
+MODULES_cflags := $(VIDEO_sdl2_cflags)
+MODULES_ldflags := $(VIDEO_sdl2_ldflags)
 ifdef SOUND
-MODULES += $(SOUND_sdl2)
+MODULES_cflags += $(SOUND_sdl2_cflags)
+MODULES_ldflags += $(SOUND_sdl2_ldflags)
 endif
 
-# Extract CFLAGS and LDFLAGS from the module definitions
-CFLAGS += $(patsubst -l%,,$(MODULES))
-LDFLAGS += $(patsubst -D%,,$(patsubst -I%,, $(MODULES)))
+CFLAGS += $(MODULES_cflags)
+LDFLAGS += $(MODULES_ldflags)
 
 # Makefile.inc contains an up-to-date set of object files to compile
 include Makefile.inc
@@ -120,8 +138,8 @@ include Makefile.inc
 # Program name (PROGNAME comes from Makefile.src via Makefile.inc)
 EXE := $(PROGNAME)
 
-# Object definitions (BASEOBJS come from Makefile.inc)
-OBJS := main.o main-sdl2.o $(BASEOBJS)
+# Object definitions (SDL2MAINFILES and BASEOBJS come from Makefile.inc)
+OBJS := main.o $(SDL2MAINFILES) $(BASEOBJS)
 
 ifdef SOUND
 OBJS += snd-sdl.o


### PR DESCRIPTION
Also inherit its splitting of compiler and linker flags.