### PR TITLE
run-tests: tolerate trailing carriage return on summary line from test

### DIFF
--- a/src/tests/run-tests
+++ b/src/tests/run-tests
@@ -75,7 +75,7 @@ sub main {
             $total += 1; 
             next;
         }
-        unless ($lines[-1] =~ m#^([^:]+) finished: (\d+)/(\d+) passed$#) {
+        unless ($lines[-1] =~ m#^([^:]+) finished: (\d+)/(\d+) passed\r?$#) {
             print red("$path: Malformed output"), "\n";
             $exitcode = 1;
             next;


### PR DESCRIPTION
That happens on MSYS2 (mingw32 environment) running on Windows with test cases from a configure-based build using --enable-win (so using carriage return + line feed as line endings) while run-tests running within the MSYS2 environment expects Unix-style line endings.