### PR TITLE
Correct reallocation used in the disconnection statistics command.

### DIFF
--- a/src/wiz-stats.c
+++ b/src/wiz-stats.c
@@ -1532,10 +1532,10 @@ static void calc_cave_distances(int **cave_dist)
 					!square_isrubble(cave, loc(tx, ty))) continue;
 
 				/* Add the new location */
-				if (n_new == cap_new - 1) {
+				if (n_new == cap_new) {
 					cap_new *= 2;
 					ngrids = mem_realloc(ngrids,
-						cap_new * sizeof(ngrids));
+						cap_new * sizeof(*ngrids));
 				}
 				ngrids[n_new].y = ty;
 				ngrids[n_new].x = tx;


### PR DESCRIPTION
Used wrong size for allocation (would be under the necessary size if sizeof(struct grid*) < sizeof(struct grid)) and would reallocate when there was still space for one more entry.