### PR TITLE
Avoid warning about unused handle_signal_suspend() on DOS (or other …

### DIFF
--- a/src/ui-signals.c
+++ b/src/ui-signals.c
@@ -49,6 +49,7 @@ static Signal_Handler_t wrap_signal(int sig, Signal_Handler_t handler)
 static Signal_Handler_t (*signal_aux)(int, Signal_Handler_t) = wrap_signal;
 
 
+#ifdef SIGTSTP
 /**
  * Handle signals -- suspend
  *
@@ -90,6 +91,7 @@ static void handle_signal_suspend(int sig)
 	/* Restore errno */
 	errno = save_errno;
 }
+#endif /* ifdef SIGTSTP */
 
 
 /**


### PR DESCRIPTION
…platforms which don't define SIGTSTP).