### PR TITLE
Workflows: drop USE_PRINTF_STYLE_CHECKS for builds with CMake

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -42,7 +42,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          env CFLAGS=-Wall cmake -DUSE_PRINTF_STYLE_CHECKS=ON ..
+          env CFLAGS=-Wall cmake ..
           make
 
   ncurses:
@@ -61,7 +61,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          env CFLAGS=-Wall cmake -DSUPPORT_GCU_FRONTEND=ON -DUSE_PRINTF_STYLE_CHECKS=ON ..
+          env CFLAGS=-Wall cmake -DSUPPORT_GCU_FRONTEND=ON ..
           make
 
   sdl:
@@ -80,7 +80,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          env CFLAGS=-Wall cmake -DSUPPORT_SDL_FRONTEND=ON -DSUPPORT_SDL_SOUND=ON -DUSE_PRINTF_STYLE_CHECKS=ON ..
+          env CFLAGS=-Wall cmake -DSUPPORT_SDL_FRONTEND=ON -DSUPPORT_SDL_SOUND=ON ..
           make
 
   sdl2:


### PR DESCRIPTION
Format argument checking is on for gcc and clang since 1168379ea574b476be28a8d2e3e7e69d7c1b2ed0 ; NarSil's CMakeLists.txt never implemented USE_PRINTF_STYLE_CHECKS .