### PR TITLE
configure: change default configpath/libpath/varpath for Windows

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -150,7 +150,7 @@ if test "x$bindir" = "x\${exec_prefix}/bin"; then
   bindir=${exec_prefix}/games
 fi
 
-if test "x$with_no_install" != "x"; then
+if test "x$with_no_install" != "x" || test "x$enable_win" = xyes ; then
 	configpath="${PWD}/lib/"
 else
 	configpath="${sysconfdir}/${PACKAGE}/"
@@ -162,7 +162,7 @@ case "/$configpath" in
 esac
 
 
-if test "x$with_no_install" != "x"; then
+if test "x$with_no_install" != "x" || test "x$enable_win" = xyes ; then
 	libpath="${PWD}/lib/"
 	bindir=".."
 else
@@ -188,7 +188,7 @@ case "/$docdir" in
 	*)  MY_EXPAND_DIR(docdatadir, "$docdir/") ;;
 esac
 
-if test "x$with_no_install" != "x"; then
+if test "x$with_no_install" != "x" || test "x$enable_win" = xyes ; then
 	varpath="${PWD}/lib/"
 else
 	varpath="${localstatedir}/games/${PACKAGE}/"


### PR DESCRIPTION
Makefiles and the game do not use those, but some test cases do.  Allows the test cases using set_file_paths() to work on Windows from builds using configure.