### PR TITLE
Avoid possible use after free when "-l" option fails

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -277,8 +277,10 @@ static void list_saves(void)
 	savefile_getter g = NULL;
 
 	if (!got_savefile(&g)) {
+		bool nodir = !got_savefile_dir(g);
+
 		cleanup_savefile_getter(g);
-		if (!got_savefile_dir(g)) {
+		if (nodir) {
 			quit_fmt("Cannot open savefile directory");
 		}
 		printf("There are no savefiles you can use.\n");


### PR DESCRIPTION
That's a post 1.3.0 regression introduced by 6d51d768833043dc198a9f8944ca7b324617af78 .