### PR TITLE
monster.txt: return missing record header for misplaced base, glyph, blow

### DIFF
--- a/src/mon-init.c
+++ b/src/mon-init.c
@@ -1518,6 +1518,9 @@ static enum parser_error parse_monster_name(struct parser *p) {
 static enum parser_error parse_monster_base(struct parser *p) {
 	struct monster_race *r = parser_priv(p);
 
+	if (!r)
+		return PARSE_ERROR_MISSING_RECORD_HEADER;
+
 	r->base = lookup_monster_base(parser_getsym(p, "base"));
 	if (r->base == NULL)
 		return PARSE_ERROR_INVALID_MONSTER_BASE;
@@ -1554,6 +1557,9 @@ static enum parser_error parse_monster_rarity(struct parser *p) {
 
 static enum parser_error parse_monster_glyph(struct parser *p) {
 	struct monster_race *r = parser_priv(p);
+
+	if (!r)
+		return PARSE_ERROR_MISSING_RECORD_HEADER;
 
 	/* If the display character is specified, it overrides any template */
 	r->d_char = parser_getchar(p, "glyph");
@@ -1672,13 +1678,14 @@ static enum parser_error parse_monster_protection(struct parser *p) {
 
 static enum parser_error parse_monster_blow(struct parser *p) {
 	struct monster_race *r = parser_priv(p);
-	struct monster_blow *b = r->blow;
+	struct monster_blow *b;
 	int att;
 
 	if (!r)
 		return PARSE_ERROR_MISSING_RECORD_HEADER;
 
 	/* Go to the last valid blow, then allocate a new one */
+	b = r->blow;
 	if (!b) {
 		r->blow = mem_zalloc(sizeof(struct monster_blow));
 		b = r->blow;

--- a/src/tests/parse/r-info.c
+++ b/src/tests/parse/r-info.c
@@ -148,6 +148,10 @@ static int test_missing_header_record0(void *state) {
 	null(mr);
 	r = parser_parse(p, "plural:red-hatted elves");
 	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "base:townsfolk");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "glyph:!");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
 	r = parser_parse(p, "depth:8");
 	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
 	r = parser_parse(p, "rarity:2");
@@ -171,6 +175,8 @@ static int test_missing_header_record0(void *state) {
 	r = parser_parse(p, "song:21");
 	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
 	r = parser_parse(p, "prot:2:1d4");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(state, "blow:CLAW:FIRE:9d12");
 	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
 	r = parser_parse(p, "flags:FRIEND");
 	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);


### PR DESCRIPTION
Those are the last three that would access a NULL pointer for a misplaced directive rather than signal a parsing error on a specific line.