### PR TITLE
Port Vanilla Angband's changes for configuring monster knowledge categories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -765,6 +765,7 @@ SET(ANGBAND_TEST_CASE_SOURCES
     parse/r-info.c
     parse/sex-info.c
     parse/slay.c
+    parse/ui_knowledge.c
     parse/v-info.c
     parse/world.c
     parse/z-info.c

--- a/docs/hacking/modifying.rst
+++ b/docs/hacking/modifying.rst
@@ -204,6 +204,10 @@ summon.txt
 tutorial.txt
   This defines the contents of the tutorial.
 
+ui_knowledge.txt
+  Handles some configuration of the knowledge menus, namely the layout of
+  the monster categories.
+
 female_entry_poetry.txt, male_entry_poetry.txt, throne_poetry.txt and
 ultimate_bug.txt define various messages that are given at special events in
 the game.

--- a/lib/gamedata/Makefile
+++ b/lib/gamedata/Makefile
@@ -7,8 +7,8 @@ FILES = ability.txt artefact.txt body.txt blow_methods.txt \
  male_entry_poetry.txt monster.txt monster_base.txt monster_spell.txt \
  names.txt object.txt object_base.txt object_property.txt pain.txt \
  player_timed.txt projection.txt pursuit.txt race.txt sex.txt slay.txt \
- song.txt special.txt summon.txt terrain.txt trap.txt tutorial.txt vault.txt \
- visuals.txt warning.txt world.txt
+ song.txt special.txt summon.txt terrain.txt trap.txt tutorial.txt \
+ ui_knowledge.txt vault.txt visuals.txt warning.txt world.txt
 
 R1 = $(GAMEDATA_IN_LIB:true=$(FILES))
 DATA = $(R1:false=)

--- a/lib/gamedata/ui_knowledge.txt
+++ b/lib/gamedata/ui_knowledge.txt
@@ -1,0 +1,121 @@
+# File: ui_knowledge.txt
+
+# Configure some behavior of the knowledge menus.
+
+# === Understanding ui_knowledge.txt ===
+
+# monster-category:name
+# mcat-include-base:name
+# mcat-include-flag:flag | ...
+
+# 'monster-category' introduces a set of directives to define a category of
+# monsters in the monster knowledge menu.  It takes one parameter:  the name
+# that will be shown in the menu for the category.  One name,
+# "***Unclassified***" is reserved for internal use to catch any types of
+# monsters that do not fall into any of the categories specified in this file.
+# In the menu, the categories will appear in the same order that they are
+# defined in this file.
+
+# 'mcat-include-base' adds a monster base to be included in the most recent
+# category specified by a 'monster-category' directive.  It takes one
+# parameter:  the name of the monster base from monster_base.txt.  If that
+# base does not exist or there is no prior 'monster-category' directive,
+# that will trigger a parser error.  This directive may be used more than
+# once for the same category.  If a category includes multiple monster bases,
+# the knowledge menu will display those from a base specified earlier in this
+# file before those from a base that appear later in this file.  Within the
+# same monster base, the knowledge menu will sort the monster types by level
+# and then by name.
+
+# 'mcat-include-flag' adds one or more monster flags to be included in the most
+# recent category specified by a 'monster-category' directive.  It takes
+# one parameter:  a list of zero or more monster flags, separated by spaces
+# or '|'.  Each flag must match one of the first arguments (except 'NONE') to
+# a RF() macro in list-mon-race-flags.h.  All types of monsters that have a
+# flag specified by 'mcat-include-flag' will be included in the category.
+# This directive may be used more than once for the same category.  Monster
+# types which only appear in a category because they possess a flag will
+# appear, when displayed in the monster knowledge menu, after those that are
+# included  because of a monster base and will be sorted by level and then
+# by name.
+
+# 'mcat-include-glyph' adds a glyph to be included in the most recent category
+# specified by a 'monster-category' directive.  It takes one parameter:  the
+# glyph to include.  All types of monsters whose default display glyph matches
+# that glyph will be included in the category.  Monster types which only appear
+# in a category because they match a glyph will appear, when displayed in the
+# monster knowledge menu, after those that are included because of a monster
+# base or flag.  If a category includes multiple glyphs, the knowledge menu
+# will display the monster types included by a glyph specified earlier in this
+# file before those included by a glyph specified later in this file.  For
+# the same glyph, the monster types will be sorted by level and then by name.
+
+monster-category:Uniques
+mcat-include-flag:UNIQUE
+
+monster-category:Bats/Birds
+mcat-include-base:flyer
+# Pick up the birds with a hallucinatory base.
+mcat-include-glyph:b
+
+monster-category:Wolves
+mcat-include-base:wolf
+# Pick up the canines with a hallucinatory base.
+mcat-include-glyph:C
+
+monster-category:Dragons
+mcat-include-base:dragon
+mcat-include-base:great dragon
+
+monster-category:Cats
+mcat-include-base:cat
+
+monster-category:Giants
+mcat-include-base:giant
+
+monster-category:Horrors
+mcat-include-base:horror
+
+monster-category:Insects
+mcat-include-base:insect
+
+monster-category:Spiders
+mcat-include-base:spider
+
+monster-category:Nameless things
+mcat-include-base:nameless thing
+
+monster-category:Orcs
+mcat-include-base:orc
+
+monster-category:Raukar
+mcat-include-base:rauko
+
+monster-category:Serpents
+mcat-include-base:serpent
+mcat-include-base:ancient serpent
+
+monster-category:Trolls
+mcat-include-base:troll
+# Pick up the ents with a hallucinatory base.
+mcat-include-glyph:T
+
+monster-category:Vampires
+mcat-include-base:vampire
+
+monster-category:Valar
+mcat-include-glyph:V
+
+monster-category:Wights/Wraiths
+mcat-include-base:wraith
+
+monster-category:Men/Elves
+mcat-include-base:person
+# Pick up the men or elves with a hallucinatory base.
+mcat-include-glyph:@
+
+monster-category:Thorns
+mcat-include-base:thorn
+
+monster-category:Deathblades
+mcat-include-base:deathblade

--- a/src/tests/parse/suite.mk
+++ b/src/tests/parse/suite.mk
@@ -26,6 +26,7 @@ TESTPROGS += parse/a-info \
 	parse/r-info \
 	parse/sex-info \
 	parse/slay \
+	parse/ui_knowledge \
 	parse/v-info \
 	parse/warning \
 	parse/world \

--- a/src/tests/parse/ui_knowledge.c
+++ b/src/tests/parse/ui_knowledge.c
@@ -1,0 +1,222 @@
+/* parse/ui_knowledge.c */
+/* Exercise parsing used for ui_knowledge.txt. */
+
+#include "unit-test.h"
+#include "ui-knowledge.h"
+#ifndef WINDOWS
+#include <locale.h>
+#include <langinfo.h>
+#endif
+
+static char dummy_bat[16] = "bat";
+static char dummy_lizard[16] = "lizard";
+static char dummy_horror[16] = "winged horror";
+static struct monster_base dummy_mon_bases[] = {
+	{ .name = dummy_bat, .next = NULL },
+	{ .name = dummy_lizard, .next = NULL },
+	{ .name = dummy_horror, .next = NULL },
+};
+
+int setup_tests(void **state) {
+	int i;
+
+	*state = ui_knowledge_parser.init();
+	/* Supply a minimal set of monster bases so the tests can function. */
+	for (i = 0; i < (int) N_ELEMENTS(dummy_mon_bases) - 1; ++i) {
+		dummy_mon_bases[i].next = dummy_mon_bases + i + 1;
+	}
+	rb_info = dummy_mon_bases;
+	return !*state;
+}
+
+int teardown_tests(void *state) {
+	struct parser *p = (struct parser*) state;
+	int r = 0;
+
+	if (ui_knowledge_parser.finish(p)) {
+		r = 1;
+	}
+	ui_knowledge_parser.cleanup();
+	return r;
+}
+
+static int test_missing_record_header0(void *state) {
+	struct parser *p = (struct parser*) state;
+	struct ui_knowledge_parse_state *s =
+		(struct ui_knowledge_parse_state*) parser_priv(p);
+	enum parser_error r;
+
+	notnull(s);
+	null(s->categories);
+	r = parser_parse(p, "mcat-include-base:bat");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "mcat-include-flag:UNIQUE");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	r = parser_parse(p, "mcat-include-glyph:V");
+	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
+	ok;
+}
+
+static int test_category0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r = parser_parse(p, "monster-category:Flying Things");
+	struct ui_knowledge_parse_state *s;
+
+	eq(r, PARSE_ERROR_NONE);
+	s = (struct ui_knowledge_parse_state*) parser_priv(p);
+	notnull(s);
+	notnull(s->categories);
+	notnull(s->categories->name);
+	require(streq(s->categories->name, "Flying Things"));
+	require(rf_is_empty(s->categories->inc_flags));
+	eq(s->categories->n_inc_bases, 0);
+	ok;
+}
+
+static int test_include_base0(void *state) {
+	struct parser *p = (struct parser*) state;
+	struct ui_knowledge_parse_state *s =
+		(struct ui_knowledge_parse_state*) parser_priv(p);
+	enum parser_error r;
+	int n_old;
+
+	notnull(s);
+	notnull(s->categories);
+	n_old = s->categories->n_inc_bases;
+	r = parser_parse(p, "mcat-include-base:bat");
+	eq(r, PARSE_ERROR_NONE);
+	/* Try adding another base. */
+	r = parser_parse(p, "mcat-include-base:winged horror");
+	eq(r, PARSE_ERROR_NONE);
+	eq(s->categories->n_inc_bases, n_old + 2);
+	notnull(s->categories->inc_bases);
+	notnull(s->categories->inc_bases[s->categories->n_inc_bases - 2]);
+	notnull(s->categories->inc_bases[s->categories->n_inc_bases - 2]->name);
+	require(streq(
+            s->categories->inc_bases[s->categories->n_inc_bases - 2]->name,
+            "bat"));
+	notnull(s->categories->inc_bases[s->categories->n_inc_bases - 1]);
+	notnull(s->categories->inc_bases[s->categories->n_inc_bases - 1]->name);
+	require(streq(
+            s->categories->inc_bases[s->categories->n_inc_bases - 1]->name,
+            "winged horror"));
+	ok;
+}
+
+static int test_include_base_bad0(void *state) {
+	struct parser *p = (struct parser*) state;
+	enum parser_error r = parser_parse(p, "mcat-include-base:XYZZY");
+
+	eq(r, PARSE_ERROR_INVALID_MONSTER_BASE);
+	ok;
+}
+
+static int test_include_flag0(void *state) {
+	struct parser *p = (struct parser*) state;
+	struct ui_knowledge_parse_state *s =
+		(struct ui_knowledge_parse_state*) parser_priv(p);
+	bitflag eflags[RF_SIZE];
+	enum parser_error r;
+
+	notnull(s);
+	notnull(s->categories);
+	rf_wipe(s->categories->inc_flags);
+	/* Check that specifying an empty set of flags works. */
+	r = parser_parse(p, "mcat-include-flag:");
+	eq(r, PARSE_ERROR_NONE);
+	require(rf_is_empty(s->categories->inc_flags));
+	/* Check that specifying one flag works. */
+	r = parser_parse(p, "mcat-include-flag:UNIQUE");
+	eq(r, PARSE_ERROR_NONE);
+	/* Check that specifying two flags at once works. */
+	r = parser_parse(p, "mcat-include-flag:MALE | NEVER_MOVE");
+	eq(r, PARSE_ERROR_NONE);
+	rf_wipe(eflags);
+	rf_on(eflags, RF_UNIQUE);
+	rf_on(eflags, RF_MALE);
+	rf_on(eflags, RF_NEVER_MOVE);
+	require(rf_is_equal(s->categories->inc_flags, eflags));
+	ok;
+}
+
+static int test_include_flag_bad0(void *state) {
+	struct parser *p = (struct parser*) state;
+	struct ui_knowledge_parse_state *s =
+		(struct ui_knowledge_parse_state*) parser_priv(p);
+	bitflag eflags[RF_SIZE];
+	enum parser_error r;
+
+	notnull(s);
+	notnull(s->categories);
+	rf_copy(eflags, s->categories->inc_flags);
+	/* Try an invalid flag. */
+	r = parser_parse(p, "mcat-include-flag:XYZZY");
+	eq(r, PARSE_ERROR_INVALID_FLAG);
+	require(rf_is_equal(s->categories->inc_flags, eflags));
+	ok;
+}
+
+static int test_include_glyph0(void *state) {
+	struct parser *p = (struct parser*) state;
+	struct ui_knowledge_parse_state *s =
+		(struct ui_knowledge_parse_state*) parser_priv(p);
+	enum parser_error r;
+	int n_old;
+
+	notnull(s);
+	notnull(s->categories);
+	n_old = s->categories->n_inc_glyphs;
+	r = parser_parse(p, "mcat-include-glyph:V");
+	eq(r, PARSE_ERROR_NONE);
+	/* Try adding some more glyphs. */
+	r = parser_parse(p, "mcat-include-glyph:b");
+	eq(r, PARSE_ERROR_NONE);
+	r = parser_parse(p, "mcat-include-glyph:@");
+	eq(r, PARSE_ERROR_NONE);
+	r = parser_parse(p, "mcat-include-glyph:T");
+	eq(r, PARSE_ERROR_NONE);
+	r = parser_parse(p, "mcat-include-glyph:C");
+	eq(r, PARSE_ERROR_NONE);
+	eq(s->categories->n_inc_glyphs, n_old + 5);
+	notnull(s->categories->inc_glyphs);
+	eq(s->categories->inc_glyphs[s->categories->n_inc_glyphs - 5], L'V');
+	eq(s->categories->inc_glyphs[s->categories->n_inc_glyphs - 4], L'b');
+	eq(s->categories->inc_glyphs[s->categories->n_inc_glyphs - 3], L'@');
+	eq(s->categories->inc_glyphs[s->categories->n_inc_glyphs - 2], L'T');
+	eq(s->categories->inc_glyphs[s->categories->n_inc_glyphs - 1], L'C');
+#ifndef WINDOWS
+	if (setlocale(LC_CTYPE, "") && streq(nl_langinfo(CODESET), "UTF-8")) {
+		/*
+		 * Check that a glyph outside of the ASCII range works.  Using
+		 * the Yen sign, U+00A5 or C2 A5 as UTF-8.
+		 */
+		wchar_t wcs[3];
+		int nc;
+
+		r = parser_parse(p, "mcat-include-glyph:¥");
+		eq(r, PARSE_ERROR_NONE);
+		eq(s->categories->n_inc_glyphs, n_old + 6);
+		notnull(s->categories->inc_glyphs);
+		nc = text_mbstowcs(wcs, "¥", (int) N_ELEMENTS(wcs));
+		eq(nc, 1);
+		eq(s->categories->inc_glyphs[s->categories->n_inc_glyphs - 1], wcs[0]);
+	}
+#endif
+	ok;
+}
+
+/*
+ * test_missing_record_header0() has to be before test_category0().
+ * All other tests except test_category0() have to be after test_category0().
+ */
+const char *suite_name = "parse/ui_knowledge";
+struct test tests[] = {
+	{ "missing_record_header0", test_missing_record_header0 },
+	{ "category0", test_category0 },
+	{ "include_base0", test_include_base0 },
+	{ "include_base_bad0", test_include_base_bad0 },
+	{ "include_flag0", test_include_flag0 },
+	{ "include_flag_bad0", test_include_flag_bad0 },
+	{ "include_glyph0", test_include_glyph0 },
+	{ NULL, NULL }
+};

--- a/src/ui-init.c
+++ b/src/ui-init.c
@@ -82,6 +82,10 @@ void textui_init(void)
 		/* Update terminals for preference changes. */
 		(void) Term_xtra(TERM_XTRA_REACT, 0);
 		(void) Term_redraw_all();
+	} else {
+		/* Redo knowledge initialization. */
+		textui_knowledge_cleanup();
+		textui_knowledge_init();
 	}
 
 	/* Initialize window options that will be overridden by any "window.prf" */

--- a/src/ui-knowledge.h
+++ b/src/ui-knowledge.h
@@ -19,6 +19,9 @@
 #ifndef UI_KNOWLEDGE_H
 #define UI_KNOWLEDGE_H
 
+#include "datafile.h"
+#include "monster.h"
+
 void textui_browse_object_knowledge(const char *name, int row);
 void textui_knowledge_init(void);
 void textui_knowledge_cleanup(void);
@@ -34,5 +37,20 @@ void do_cmd_query_symbol(void);
 void do_cmd_center_map(void);
 void do_cmd_monlist(void);
 void do_cmd_itemlist(void);
+
+/* Exposed for use by test cases. */
+struct ui_monster_category {
+	struct ui_monster_category *next;
+	const char *name;
+	const struct monster_base **inc_bases;
+	wchar_t *inc_glyphs;
+	bitflag inc_flags[RF_SIZE];
+	int n_inc_bases, max_inc_bases;
+	int n_inc_glyphs, max_inc_glyphs;
+};
+struct ui_knowledge_parse_state {
+	struct ui_monster_category *categories;
+};
+extern struct file_parser ui_knowledge_parser;
 
 #endif /* UI_KNOWLEDGE_H */

--- a/src/win/vs2019/Angband.vcxproj
+++ b/src/win/vs2019/Angband.vcxproj
@@ -620,6 +620,7 @@ xcopy $(MSBuildProjectDirectory)\lib\* $(OutDir)lib\ /DESY /exclude:$(MSBuildPro
     <Text Include="lib\gamedata\ui_entry.txt" />
     <Text Include="lib\gamedata\ui_entry_base.txt" />
     <Text Include="lib\gamedata\ui_entry_renderer.txt" />
+    <Text Include="lib\gamedata\ui_knowledge.txt" />
     <Text Include="lib\gamedata\vault.txt" />
     <Text Include="lib\gamedata\visuals.txt" />
     <Text Include="lib\gamedata\world.txt" />

--- a/src/win/vs2019/Angband.vcxproj.filters
+++ b/src/win/vs2019/Angband.vcxproj.filters
@@ -1404,6 +1404,9 @@
     <Text Include="lib\gamedata\ui_entry_renderer.txt">
       <Filter>Resource Files\gamedata</Filter>
     </Text>
+    <Text Include="lib\gamedata\ui_knowledge.txt">
+      <Filter>Resource Files\gamedata</Filter>
+    </Text>
     <Text Include="lib\gamedata\vault.txt">
       <Filter>Resource Files\gamedata</Filter>
     </Text>


### PR DESCRIPTION
Now configured via lib/gamedata/ui_knowledge.txt rather than hardwired categories in src/ui-knowledge.c.  The ordering of hallucinatory monsters in the categories will likely be different than before:  they'll appear last, after any non-hallucinatory monsters in the category.