### PR TITLE
Use wchar_t to store glyphs for the attacker/defender in combat rolls

### DIFF
--- a/src/ui-combat.c
+++ b/src/ui-combat.c
@@ -141,13 +141,13 @@ void update_combat_rolls_attack(game_event_type type, game_event_data *data,
 				combat_rolls[0][combat_number].attacker_attr = race1->d_attr;
 			}
 		} else {
-			combat_rolls[0][combat_number].attacker_char = '?';
+			combat_rolls[0][combat_number].attacker_char = L'?';
 			combat_rolls[0][combat_number].attacker_attr = COLOUR_SLATE;
 		}
 
 		if ((defender.what == SRC_NONE) && melee) {
 			/* Hack for Iron Crown */
-			combat_rolls[0][combat_number].defender_char = ']';
+			combat_rolls[0][combat_number].defender_char = L']';
 			combat_rolls[0][combat_number].defender_attr = COLOUR_L_DARK;
 		} else if ((vis && (defender.what == SRC_MONSTER))
 				|| (defender.what == SRC_PLAYER)) {
@@ -159,7 +159,7 @@ void update_combat_rolls_attack(game_event_type type, game_event_data *data,
 				combat_rolls[0][combat_number].defender_attr = race2->d_attr;
 			}
 		} else {
-			combat_rolls[0][combat_number].defender_char = '?';
+			combat_rolls[0][combat_number].defender_char = L'?';
 			combat_rolls[0][combat_number].defender_attr = COLOUR_SLATE;
 		}
 

--- a/src/ui-combat.h
+++ b/src/ui-combat.h
@@ -37,9 +37,9 @@ struct combat_roll {
 	int att_type;			/* The type of attack - enum combat_roll_type */
 	int dam_type;			/* The type of damage (GF_HURT, GF_FIRE etc) */
 
-	char attacker_char;		/* The symbol of the attacker */
+	wchar_t attacker_char;		/* The symbol of the attacker */
 	uint8_t attacker_attr;		/* Default attribute of the attacker */
-	char defender_char;		/* The symbol of the defender */
+	wchar_t defender_char;		/* The symbol of the defender */
 	uint8_t defender_attr;		/* Default attribute of the defender */
 	int att;				/* The attack bonus */
 	int att_roll;			/* The attack roll (d20 value) */


### PR DESCRIPTION
Resolves the sixth part of https://github.com/NickMcConnell/NarSil/issues/735 .