### PR TITLE
Remove declaration for obj_is_known_artifact()

### DIFF
--- a/src/obj-util.h
+++ b/src/obj-util.h
@@ -55,7 +55,6 @@ bool obj_can_fire(const struct object *obj);
 bool obj_is_throwing(const struct object *obj);
 bool obj_is_cursed(const struct object *obj);
 bool obj_is_broken(const struct object *obj);
-bool obj_is_known_artifact(const struct object *obj);
 bool obj_has_inscrip(const struct object *obj);
 bool obj_has_flag(const struct object *obj, int flag);
 bool obj_is_useable(const struct object *obj);


### PR DESCRIPTION
It is no longer present and was replaced by object_is_known_artifact() in obj-knowledge.{c,h}.