### PR TITLE
Correct writing lore when there is more than one known drop (1.3 branch)

### DIFF
--- a/src/mon-lore.c
+++ b/src/mon-lore.c
@@ -1343,10 +1343,11 @@ static void write_lore_entries(ang_file *fff)
 		/* Output 'drop' */
 		if (lore->drops) {
 			struct monster_drop *drop = lore->drops;
-			struct object_kind *kind = drop->kind;
 			char name[120] = "";
 
 			while (drop) {
+				struct object_kind *kind = drop->kind;
+
 				if (kind) {
 					object_short_name(name, sizeof name, kind->name);
 					file_putf(fff, "drop:%s:%s:%d:%d:%d\n",


### PR DESCRIPTION
Resolves https://github.com/NickMcConnell/NarSil/issues/764 .