### PR TITLE
Smithing: have known version in special_display() and artefact_display()

### DIFF
--- a/src/obj-smith.c
+++ b/src/obj-smith.c
@@ -1384,6 +1384,10 @@ static void create_smithing_item(struct object *obj, struct smithing_cost *cost)
 
 	/* Create the object */
 	object_copy(created, obj);
+	if (obj->known) {
+		created->known = object_new();
+		object_copy(created->known, obj->known);
+	}
 	
 	/* Identify the object */
 	object_flavor_aware(player, created);

--- a/src/ui-smith.c
+++ b/src/ui-smith.c
@@ -608,9 +608,9 @@ static void special_display(struct menu *menu, int oid, bool cursor, int row,
 	uint8_t attr = affordable_specials[oid] ? COLOUR_WHITE : COLOUR_SLATE;
 	if (cursor) {
 		create_special(smith_obj, choice[oid]);
+		know_smith_obj();
 		pval = pval_valid(smith_obj) ? smith_obj->pval : 0;
 		include_pval(smith_obj);
-		know_smith_obj();
 		show_smith_obj();
 		exclude_pval(smith_obj);
 	}
@@ -890,8 +890,8 @@ static void artefact_display(struct menu *menu, int oid, bool cursor, int row,
 	attr = smithing_art_cat_counts[oid] > 0 ?
 		(cursor ? COLOUR_L_BLUE : COLOUR_WHITE) : COLOUR_L_DARK;
 	if (cursor) {
-		include_pval(smith_obj);
 		know_smith_obj();
+		include_pval(smith_obj);
 		show_smith_obj();
 		exclude_pval(smith_obj);
 	}


### PR DESCRIPTION
When smithed object is accepted, copy the known version into dynamically allocated memory so that later cleanup does not try to deallocated statically allocated memory.  Resolves the crash reported on 2024/11/5 for https://github.com/NickMcConnell/NarSil/issues/728 .