### PR TITLE
Point object for accepted smithed artifact to artifact's permanent record (1.3)

### DIFF
--- a/src/obj-smith.c
+++ b/src/obj-smith.c
@@ -1376,6 +1376,12 @@ static void create_smithing_item(struct object *obj, struct smithing_cost *cost)
 		aup_info[aidx].created = true;
 		aup_info[aidx].seen = true;
 		aup_info[aidx].everseen = true;
+
+		/*
+		 * Point the object at the permanent artifact record rather
+		 * than what is used when smithing.
+		 */
+		obj->artifact = &a_info[aidx];
 	}
 
 	/* Create the object */


### PR DESCRIPTION
Prevents future smithing attempts before a save and reload from affecting the obect. Resolves #769 .