### PR TITLE
Allow non-instant artifact colors without inteference for other objects (1.3 branch)

### DIFF
--- a/src/cave-map.c
+++ b/src/cave-map.c
@@ -46,6 +46,9 @@
  *    player doesn't know it).
  *  - g->first_kind is set to the object_kind of the first object in a grid
  *    that the player knows about, or NULL for no objects.
+ *  - g->first_art is set to the artifact pointer of the first object in a grid
+ *    that the player knows about, or NULL if there are no objects or the first
+ *    known object is not an artifact.
  *  - g->muliple_objects is true if there is more than one object in the
  *    grid that the player knows and cares about (to facilitate any special
  *    floor stack symbol that might be used).
@@ -88,6 +91,7 @@ void map_info(struct loc grid, struct grid_data *g)
 
 	/* Default "clear" values, others will be set later where appropriate. */
 	g->first_kind = NULL;
+	g->first_art = NULL;
 	g->trap = NULL;
 	g->multiple_objects = false;
 	g->glow = false;
@@ -156,6 +160,7 @@ void map_info(struct loc grid, struct grid_data *g)
 			/* Item stays hidden */
 		} else if (!g->first_kind) {
 			g->first_kind = obj->kind;
+			g->first_art = obj->artifact;
 			g->glow = weapon_glows(obj);
 		} else {
 			g->multiple_objects = true;

--- a/src/cave.h
+++ b/src/cave.h
@@ -154,6 +154,7 @@ struct grid_data {
 	uint32_t m_idx;			/* Monster index */
 	uint32_t f_idx;			/* Feature index */
 	struct object_kind *first_kind;	/* The kind of the first item on the grid */
+	const struct artifact *first_art;	/* Artifact pointer for first item on the grid */
 	struct trap *trap;		/* Trap */
 	bool multiple_objects;	/* Is there more than one item there? */
 

--- a/src/object.h
+++ b/src/object.h
@@ -305,6 +305,7 @@ struct artifact {
 
 	uint8_t level;			/* Artefact level */
 	uint8_t rarity;		/* Artefact rarity */
+	uint8_t d_attr;			/**< Display color */
 };
 
 /**

--- a/src/ui-map.c
+++ b/src/ui-map.c
@@ -227,7 +227,9 @@ void grid_data_as_text(struct grid_data *g, int *ap, wchar_t *cp, int *tap,
 			c = object_kind_char(pile_kind);
 		} else {
 			/* Normal attr and char, check for glowing */
-			a = g->glow ? COLOUR_L_BLUE : object_kind_attr(g->first_kind);
+			a = g->glow ? COLOUR_L_BLUE :
+				((g->first_art) ? g->first_art->d_attr :
+				object_kind_attr(g->first_kind));
 			c = object_kind_char(g->first_kind);
 		}
 		if (g->rage) a = COLOUR_RED;

--- a/src/ui-obj-list.c
+++ b/src/ui-obj-list.c
@@ -134,8 +134,8 @@ static void object_list_format_section(const object_list_t *list,
 
 			if (object_is_known(list->entries[entry_index].object) &&
 				list->entries[entry_index].object->kind != NULL) {
-				a = object_kind_attr(list->entries[entry_index].object->kind);
-				c = object_kind_char(list->entries[entry_index].object->kind);
+				a = object_attr(list->entries[entry_index].object);
+				c = object_char(list->entries[entry_index].object);
 			}
 
 			textblock_append_pict(tb, a, c);

--- a/src/ui-object.c
+++ b/src/ui-object.c
@@ -114,7 +114,8 @@ wchar_t object_kind_char(const struct object_kind *kind)
  */
 uint8_t object_attr(const struct object *obj)
 {
-	return object_kind_attr(obj->kind);
+	return obj->artifact ?
+		obj->artifact->d_attr : object_kind_attr(obj->kind);
 }
 
 /**


### PR DESCRIPTION
Resolves https://github.com/NickMcConnell/NarSil/issues/563 .