### PR TITLE
Ensure archive directory presence if running Windows front end in place (1.3 branch)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -705,6 +705,7 @@ IF(SC_INSTALL)
         "${CMAKE_CURRENT_SOURCE_DIR}/lib"
         "Makefile"
         ".deps"
+        ".gitignore"
         COMMENT "Copying needed files"
         VERBATIM
     )

--- a/lib/user/archive/.gitignore
+++ b/lib/user/archive/.gitignore
@@ -1,0 +1,8 @@
+# This directory is used for randart files and borg dumps if running the
+# game from where it was built and using the Windows front end (main-win.c)
+# or a front end that uses main.c but was compiled without PRIVATE_USER_PATH
+# set.  Front ends using main.c would create this directory if needed, but
+# main-win.c does not.
+# For git, ignore everything here except for this file.
+*
+!.gitignore

--- a/src/main-win.c
+++ b/src/main-win.c
@@ -5110,6 +5110,7 @@ static void init_stuff(void)
 	validate_dir(ANGBAND_DIR_SAVE);
 	validate_dir(ANGBAND_DIR_PANIC);
 	validate_dir(ANGBAND_DIR_SCORES);
+	validate_dir(ANGBAND_DIR_ARCHIVE);
 
 	/* Build the filename */
 	path_build(path, sizeof(path), ANGBAND_DIR_SCREENS, "news.txt");


### PR DESCRIPTION
Also ensures lib/user/archive is set up for self-contained installs via CMake.