### PR TITLE
Replace most square_ismark() calls with square_isknown() or square_isseen()

### DIFF
--- a/src/cave-fire.c
+++ b/src/cave-fire.c
@@ -1221,7 +1221,7 @@ int project_path(struct chunk *c, struct loc *gp, int range, struct loc grid1,
 			//TODO see if this conditional is actually needed; I believe it's
 			//purpose is covered by the checks in projectable() - NRM
 			//if ((!require_strict_lof) || square_isfire(c, grid) ||
-			//   ((flg & (PROJECT_INVIS)) && !square_ismark(c, grid))) {
+			//   ((flg & (PROJECT_INVIS)) && !square_isknown(c, grid))) {
 			/* Store grid value */
 			tmp_grids[n_grids++] = grid_to_loc(g);
 				//}
@@ -1235,7 +1235,7 @@ int project_path(struct chunk *c, struct loc *gp, int range, struct loc grid1,
 		 * but the path cannot pass through them.
 		 */
 		if (!(flg & (PROJECT_PASS)) && square_iswall(c, grid)) {
-			if (!(flg & (PROJECT_INVIS)) || square_ismark(c, grid)) {
+			if (!(flg & (PROJECT_INVIS)) || square_isknown(c, grid)) {
 				/* Clear any lines of sight passing through this grid */
 				bits0 &= ~(point->bits_0);
 				bits1 &= ~(point->bits_1);
@@ -1293,7 +1293,7 @@ int project_path(struct chunk *c, struct loc *gp, int range, struct loc grid1,
 
 			/* Usually stop at wall grids */
 			if (!(flg & (PROJECT_PASS)) &&
-				(!(flg & (PROJECT_INVIS)) || square_ismark(c, grid))) {
+				(!(flg & (PROJECT_INVIS)) || square_isknown(c, grid))) {
 				if (!square_isprojectable(c, grid)) {
 					blockage[i] = 2;
 				}

--- a/src/cmd-cave.c
+++ b/src/cmd-cave.c
@@ -1242,7 +1242,7 @@ void do_cmd_disarm(struct command *cmd)
 static bool do_cmd_bash_test(struct player *p, struct loc grid)
 {
 	/* Must have knowledge */
-	if (!square_ismark(cave, grid)) {
+	if (!square_isknown(cave, grid)) {
 		/* Message */
 		msg("You see nothing there.");
 
@@ -1449,8 +1449,8 @@ static void do_cmd_alter_aux(int dir)
 	if (square(cave, grid)->mon > 0) {
 		/* Attack monster */
 		py_attack(player, grid, ATT_MAIN);
-	} else if ((dir != DIR_NONE) && !square_ismark(cave, grid)) {
-		/* Deal with players who can't see the square */
+	} else if ((dir != DIR_NONE) && !square_isknown(cave, grid)) {
+		/* Deal with players who don't know what is there. */
 		if (square_isfloor(cave, grid)) {
 			msg("You strike, but there is nothing there.");
 		} else {
@@ -1536,7 +1536,7 @@ static bool confirm_leap(struct loc grid, int dir)
 	struct monster *mon = square_monster(cave, end);
 
 	/* Prompt for confirmation */
-	if (!(square_isseen(cave, end) || square_ismark(cave, end))) {
+	if (!(square_isseen(cave, end) || square_isknown(cave, end))) {
 		/* Confirm if the destination is unknown */
 		strnfmt(prompt, sizeof(prompt),
 				"Are you sure you wish to leap into the unknown? ");
@@ -1766,7 +1766,7 @@ void move_player(int dir, bool disarm)
 		bool step = true;
 
 		/* Check before walking on known traps/chasms on movement */
-		if (!confused && square_ismark(cave, grid)) {
+		if (!confused && square_isknown(cave, grid)) {
 			/* If the player hasn't already leapt */
 			if (square_ischasm(cave, grid)) {
 				/* Disturb the player */

--- a/src/generate.c
+++ b/src/generate.c
@@ -781,7 +781,7 @@ void prepare_next_level(struct player *p)
 				}
 
 				/* Greater vaults */
-				if (!noted && square_ismark(cave, grid) &&
+				if (!noted && square_isknown(cave, grid) &&
 					square_isgreatervault(cave, grid)) {
 					history_add(p, format("Left without entering %s",
 										  cave->vault_name), HIST_VAULT_LOST);

--- a/src/player-util.c
+++ b/src/player-util.c
@@ -673,7 +673,7 @@ bool player_can_leap(struct player *p, struct loc grid, int dir)
 		/* Can't jump without a run up */
 		msg("You cannot leap without a run up.");
 		return false;
-	} else if (square_ismark(cave, end) && !square_ispassable(cave, end)) {
+	} else if (square_isknown(cave, end) && !square_ispassable(cave, end)) {
 		/* Need room to land */
 		msg("You cannot leap over as there is no room to land.");
 		return false;
@@ -1439,14 +1439,14 @@ static void search_square(struct player *p, struct loc grid, int dist,
 
 	/* If searching, discover unknown adjacent squares of interest */
 	if (searching) {
-		if ((dist == 1) && !square_ismark(cave, grid)) {
+		if ((dist == 1) && !square_isknown(cave, grid)) {
 			struct object *square_obj = square_object(cave, grid);
 
-			/* Mark all non-floor non-trap squares */
-            if (!(square_isfloor(cave, grid) ||
-				  square_issecrettrap(cave, grid))) {
-                sqinfo_on(square(cave, grid)->info, SQUARE_MARK);
-            }
+			/* Remember all non-floor non-trap squares */
+			if (!(square_isfloor(cave, grid) ||
+					square_issecrettrap(cave, grid))) {
+				square_memorize(cave, grid);
+			}
 			
 			/* Mark an object, but not the square it is in */
 			if (square_obj) {

--- a/src/project-feat.c
+++ b/src/project-feat.c
@@ -144,68 +144,72 @@ static void project_feature_handler_KILL_WALL(project_feature_handler_context_t 
 	if (square_isrubble(cave, grid)) {
 		if (success) {
 			/* Message */
-			if (square_ismark(cave, grid)) {
+			if (square_isseen(cave, grid)) {
 				msg("The rubble is blown away!");
 				context->obvious = true;
 
 				/* Forget the rubble */
-				square_unmark(cave, grid);
+				square_forget(cave, grid);
+				square_light_spot(cave, grid);
 			}
 
 			/* Destroy the rubble */
 			square_destroy_rubble(cave, grid);
-		} else if (square_ismark(cave, grid)) {
+		} else if (square_isseen(cave, grid)) {
 			/* Message */
 			msg("You fail to blow hard enough to smash the rubble.");
 		}
 	} else if (square_iscloseddoor(cave, grid)) {
 		if (success) {
 			/* Message */
-			if (square_ismark(cave, grid)) {
+			if (square_isseen(cave, grid)) {
 				msg("The door is blown from its hinges!");
 				context->obvious = true;
 
 				/* Forget the door */
-				square_unmark(cave, grid);
+				square_forget(cave, grid);
+				square_light_spot(cave, grid);
 			}
 
 			/* Destroy the door */
 			square_destroy_door(cave, grid);
-		} else if (square_ismark(cave, grid)) {
+		} else if (square_isseen(cave, grid)) {
 			/* Message */
 			msg("You fail to blow hard enough to force the door open.");
 		}
 	} else if (square_isquartz(cave, grid)) {
 		if (success) {
 			/* Message */
-			if (square_ismark(cave, grid)) {
+			if (square_isseen(cave, grid)) {
 				msg("The vein shatters!");
 				context->obvious = true;
 
 				/* Forget the wall */
-				square_unmark(cave, grid);
+				square_forget(cave, grid);
+				square_light_spot(cave, grid);
 			}
 
 			/* Destroy the wall */
 			square_set_feat(cave, grid, FEAT_RUBBLE);
-		} else if (square_ismark(cave, grid)) {
+		} else if (square_isseen(cave, grid)) {
 			/* Message */
 			msg("You fail to blow hard enough to shatter the quartz.");
 		}
 	} else if (square_isgranite(cave, grid)) {
 		if (success) {
 			/* Message */
-			if (square_ismark(cave, grid)) {
+			if (square_isseen(cave, grid)) {
 				msg("The wall shatters!");
 				context->obvious = true;
 
 				/* Forget the wall */
-				square_unmark(cave, grid);
+				square_forget(cave, grid);
+				square_light_spot(cave, grid);
 			}
 
 			/* Destroy the wall */
 			square_set_feat(cave, grid, FEAT_RUBBLE);
-		} else if (square_ismark(cave, grid)) {
+		} else if (square_isseen(cave, grid)) {
 			/* Message */
 			msg("You fail to blow hard enough to shatter the wall.");
 		}


### PR DESCRIPTION
Affects bashing doors, altering terrain, confirmations for moving/leaping into a hazardous situation, searching, and describing the results of a horn of blasting.