### PR TITLE
Make weapon_glows() a bit more efficient

### DIFF
--- a/src/cave-map.c
+++ b/src/cave-map.c
@@ -165,7 +165,7 @@ void map_info(struct loc grid, struct grid_data *g)
 			g->first_art = obj->artifact;
 			assert(base_obj);
 			g->glow = loc_eq(obj->grid, base_obj->grid)
-				&& weapon_glows(base_obj);
+				&& weapon_glows(base_obj, 0);
 		} else {
 			g->multiple_objects = true;
 			break;

--- a/src/cave-view.c
+++ b/src/cave-view.c
@@ -728,7 +728,7 @@ static void calc_lighting(struct chunk *c, struct player *p)
 		}
 
 		/* Is it a glowing weapon? */
-		if (weapon_glows(obj)) {
+		if (weapon_glows(obj, 1)) {
 			light++;
 		}
 

--- a/src/player-calcs.h
+++ b/src/player-calcs.h
@@ -108,7 +108,7 @@ uint8_t total_ads(struct player *p, struct player_state *state,
 int equipped_item_slot(struct player_body body, struct object *obj);
 void calc_inventory(struct player *p);
 void calc_voice(struct player *p, bool update);
-bool weapon_glows(struct object *obj);
+bool weapon_glows(struct object *obj, int near);
 void calc_light(struct player *p);
 int weight_limit(struct player_state state);
 int weight_remaining(struct player *p);


### PR DESCRIPTION
Return early if the weapon has no slays and break out of the viewable calculation early once the weapon is known to be viewable.