### PR TITLE
Make weapon_glows() a bit more efficient - 1.3 branch

### DIFF
--- a/src/cave-map.c
+++ b/src/cave-map.c
@@ -161,7 +161,7 @@ void map_info(struct loc grid, struct grid_data *g)
 		} else if (!g->first_kind) {
 			g->first_kind = obj->kind;
 			g->first_art = obj->artifact;
-			g->glow = weapon_glows(obj);
+			g->glow = weapon_glows(obj, 0);
 		} else {
 			g->multiple_objects = true;
 			break;

--- a/src/cave-view.c
+++ b/src/cave-view.c
@@ -728,7 +728,7 @@ static void calc_lighting(struct chunk *c, struct player *p)
 		}
 
 		/* Is it a glowing weapon? */
-		if (weapon_glows(obj)) {
+		if (weapon_glows(obj, 1)) {
 			light++;
 		}
 

--- a/src/player-calcs.c
+++ b/src/player-calcs.c
@@ -532,29 +532,43 @@ static int hate_level(struct loc grid, int multiplier)
 
 /**
  * Determine whether a melee weapon is glowing in response to nearby enemies
+ *
+ * \param obj is the object to test.
+ * \param near affects the line of sight check.  If there's a grid in the
+ * player's line of sight that is in the square centered on the object with
+ * side length near + 1, then the glowing effect, if any, will be visible.
+ * near must be non-negative.
  */
-bool weapon_glows(struct object *obj)
+bool weapon_glows(struct object *obj, int near)
 {
 	int i, total_hate = 0;
 	struct loc grid, obj_grid;
-	bool viewable = false;
 
 	if (!character_dungeon) return false;
 
-	/* Must be a melee weapon */
-	if (!tval_is_melee_weapon(obj)) return false;
+	/* Must be a melee weapon with slays */
+	if (!tval_is_melee_weapon(obj) || !obj->slays) return false;
 
 	/* Use the player's position where needed */
 	obj_grid = loc_is_zero(obj->grid) ? player->grid : obj->grid;
 	
 	/* Out of LOS objects don't glow (or it can't be seen) */
-	for (grid.y = obj_grid.y - 1; grid.y <= obj_grid.y + 1; grid.y++) {
-		for (grid.x = obj_grid.x - 1; grid.x <= obj_grid.x + 1; grid.x++) {
-			if (!square_in_bounds(cave, grid)) continue;
-			if (square_isview(cave, grid)) viewable = true;
+	assert(near >= 0);
+	grid.x = obj_grid.x - near;
+	grid.y = obj_grid.y - near;
+	while (1) {
+		if (square_in_bounds(cave, grid) && square_isview(cave, grid)) {
+			break;
+		}
+		++grid.x;
+		if (grid.x > obj_grid.x + near) {
+			++grid.y;
+			if (grid.y > obj_grid.y + near) {
+				return false;
+			}
+			grid.x = obj_grid.x - near;
 		}
 	}
-	if (!viewable) return false;
 
 	/* Create a 'flow' around the object */
 	cave->monster_noise.centre = obj_grid;
@@ -572,7 +586,7 @@ bool weapon_glows(struct object *obj)
 
 		/* Determine if a slay is applicable */
 		for (j = 0; j < z_info->slay_max; j++) {
-			if (obj->slays && obj->slays[j] &&
+			if (obj->slays[j] &&
 				rf_has(race->flags, slays[j].race_flag)) {
 				target = true;
 				break;
@@ -596,7 +610,7 @@ bool weapon_glows(struct object *obj)
 	for (i = 0; i < z_info->slay_max; i++) {
 		if (slays[i].race_flag == RF_SPIDER) break;
 	}
-	if (obj->slays && obj->slays[i]) {
+	if (i < z_info->slay_max && obj->slays[i]) {
 		for (grid.y = obj_grid.y - 2; grid.y <= obj_grid.y + 2; grid.y++) {
 			for (grid.x = obj_grid.x - 2; grid.x <= obj_grid.x + 2; grid.x++) {
 				if (square_in_bounds(cave, grid) &&
@@ -653,8 +667,8 @@ void calc_light(struct player *p)
 	}
 
 	/* Increase radius when the player's weapon glows */
-	if (main_weapon && weapon_glows(main_weapon)) new_light++;
-	if (second_weapon && weapon_glows(second_weapon)) new_light++;
+	if (main_weapon && weapon_glows(main_weapon, 0)) new_light++;
+	if (second_weapon && weapon_glows(second_weapon, 0)) new_light++;
 
 	/* Player is darkened */
 	if (p->timed[TMD_DARKENED] && (new_light > 0)) new_light--;

--- a/src/player-calcs.h
+++ b/src/player-calcs.h
@@ -108,7 +108,7 @@ uint8_t total_ads(struct player *p, struct player_state *state,
 int equipped_item_slot(struct player_body body, struct object *obj);
 void calc_inventory(struct player *p);
 void calc_voice(struct player *p, bool update);
-bool weapon_glows(struct object *obj);
+bool weapon_glows(struct object *obj, int near);
 void calc_light(struct player *p);
 int weight_limit(struct player_state state);
 int weight_remaining(struct player *p);


### PR DESCRIPTION
Return early if the weapon has no slays and break out of the viewable calculation early once the weapon is known to be viewable.