### PR TITLE
Microchasm's tiles: support the alert and glow indicators - 1.3 branch

### DIFF
--- a/lib/tiles/microchasm/graf-mcm.prf
+++ b/lib/tiles/microchasm/graf-mcm.prf
@@ -9,6 +9,13 @@
 # Adapted from the file "graf-new.prf" in Sil-q 1.5 along with the pixmap
 # file itself.
 
+##### Special attr/char values #####
+
+GS:ALERT:0x8C:0x8B
+GS:GLOW::0x8C:0x8E
+
+
+
 
 ##### Spell attr/char values #####
 

--- a/src/main-sdl2.c
+++ b/src/main-sdl2.c
@@ -1070,6 +1070,8 @@ static void render_tile_font_scaled(const struct subwindow *subwindow,
 
 	int src_row = a & 0x7f;
 	int src_col = c & 0x7f;
+	bool alert = (a & GRAPHICS_ALERT_MASK);
+	bool glow = (a & GRAPHICS_GLOW_MASK);
 
 	src.x = src_col * src.w;
 	src.y = src_row * src.h;
@@ -1084,11 +1086,39 @@ static void render_tile_font_scaled(const struct subwindow *subwindow,
 		dst.h *= 2;
 		src.h *= 2;
 
+		/* For now, do not deal with glow for double-height tiles. */
 		SDL_RenderCopy(subwindow->window->renderer,
 				graphics->texture, &src, &dst);
+		if (alert) {
+			/*
+			 * The alert indicator is not double height; render
+			 * it to the top half.
+			 */
+			src.h = dst.h / 2;
+			src.x = (alert_x_char & 0x7f) * src.w;
+			src.y = (alert_x_attr & 0x7f) * src.h;
+			SDL_RenderCopy(subwindow->window->renderer,
+				graphics->texture, &src, &dst);
+		}
 	} else {
+		if (glow) {
+			SDL_Rect glow_src;
+
+			glow_src.x = (glow_x_char & 0x7f) * src.w;
+			glow_src.y = (glow_x_attr & 0x7f) * src.h;
+			glow_src.w = src.w;
+			glow_src.h = src.h;
+			SDL_RenderCopy(subwindow->window->renderer,
+				graphics->texture, &glow_src, &dst);
+		}
 		SDL_RenderCopy(subwindow->window->renderer,
 				graphics->texture, &src, &dst);
+		if (alert) {
+			src.x = (alert_x_char & 0x7f) * src.w;
+			src.y = (alert_x_attr & 0x7f) * src.h;
+			SDL_RenderCopy(subwindow->window->renderer,
+				graphics->texture, &src, &dst);
+		}
 	}
 }
 

--- a/src/ui-prefs.c
+++ b/src/ui-prefs.c
@@ -52,6 +52,10 @@ uint8_t *trap_x_attr[LIGHTING_MAX];
 wchar_t *trap_x_char[LIGHTING_MAX];
 uint8_t *flavor_x_attr;
 wchar_t *flavor_x_char;
+uint8_t alert_x_attr = 0;
+wchar_t alert_x_char = 0;
+uint8_t glow_x_attr = 0;
+wchar_t glow_x_char = 0;
 static size_t flavor_max = 0;
 
 /**
@@ -875,6 +879,29 @@ static enum parser_error parse_prefs_gf(struct parser *p)
 	return PARSE_ERROR_NONE;
 }
 
+static enum parser_error parse_prefs_gs(struct parser *p)
+{
+	struct prefs_data *d = parser_priv(p);
+	const char *name = parser_getsym(p, "type");
+	int x_attr = parser_getint(p, "attr");
+	int x_char = parser_getint(p, "char");
+
+	assert(d != NULL);
+	if (d->bypass) return PARSE_ERROR_NONE;
+
+	if (streq(name, "ALERT")) {
+		alert_x_attr = (uint8_t)x_attr;
+		alert_x_char = (wchar_t)x_char;
+	} else if (streq(name, "GLOW")) {
+		glow_x_attr = (uint8_t)x_attr;
+		glow_x_char = (wchar_t)x_char;
+	} else {
+		return PARSE_ERROR_UNRECOGNISED_PARAMETER;
+	}
+
+	return PARSE_ERROR_NONE;
+}
+
 static enum parser_error parse_prefs_flavor(struct parser *p)
 {
 	unsigned int idx;
@@ -1076,6 +1103,7 @@ static struct parser *init_parse_prefs(bool user)
 	parser_reg(p, "feat sym idx sym lighting int attr int char", parse_prefs_feat);
 	parser_reg(p, "trap sym idx sym lighting int attr int char", parse_prefs_trap);
 	parser_reg(p, "GF sym type sym direction uint attr uint char", parse_prefs_gf);
+	parser_reg(p, "GS sym type int attr int char", parse_prefs_gs);
 	parser_reg(p, "flavor uint idx int attr int char", parse_prefs_flavor);
 	parser_reg(p, "inscribe sym tval sym sval str text", parse_prefs_inscribe);
 	parser_reg(p, "keymap-act ?str act", parse_prefs_keymap_action);
@@ -1369,6 +1397,10 @@ void textui_prefs_init(void)
 			flavor_max = f->fidx;
 	flavor_x_attr = mem_zalloc((flavor_max + 1) * sizeof(uint8_t));
 	flavor_x_char = mem_zalloc((flavor_max + 1) * sizeof(wchar_t));
+	alert_x_attr = 0;
+	alert_x_char = 0;
+	glow_x_attr = 0;
+	glow_x_char = 0;
 
 	reset_visuals(false);
 }

--- a/src/ui-prefs.h
+++ b/src/ui-prefs.h
@@ -43,6 +43,10 @@ extern uint8_t *trap_x_attr[LIGHTING_MAX];
 extern wchar_t *trap_x_char[LIGHTING_MAX];
 extern uint8_t *flavor_x_attr;
 extern wchar_t *flavor_x_char;
+extern uint8_t alert_x_attr;
+extern wchar_t alert_x_char;
+extern uint8_t glow_x_attr;
+extern wchar_t glow_x_char;
 
 /**
  * Private data for pref file parsing.

--- a/src/z-color.h
+++ b/src/z-color.h
@@ -89,6 +89,16 @@
 #define BG_DARK  2	/* The set number for the dark-background glyphs */
 #define BG_MAX   3	/* The max number of backgrounds */
 
+/*
+ * These are bits set in the attribute to trigger special rendering when using
+ * tiles.  These bits should not overlap with bits in 0x00 to 0xFF (either
+ * color indices with background values or tile indices).
+ */
+#define GRAPHICS_ALERT_MASK 0x100	/* used for alert monsters if the tiles
+						have an alert indicator */
+#define GRAPHICS_GLOW_MASK 0x200	/* used for glowing objects if the tiles
+						have a glow indicator */
+
 /**
  * A game color.
  */


### PR DESCRIPTION
Resolves the second part of https://github.com/NickMcConnell/NarSil/issues/608 .  For other tile sets which support transparency, would need to add tiles for the glow and alert indicators and then reference those tiles in the preference file.  The current implementation assumes that no double-height tile will get the glow indicator.  If that assumption is wrong, would need to allow for both single-height and double-height glow indicators in ui-prefs.c and change the rendering logic to support a double-height glow indicator.