### PR TITLE
Get highlight_unwary option to work again - 1.3 branch

### DIFF
--- a/src/ui-map.c
+++ b/src/ui-map.c
@@ -203,7 +203,7 @@ void grid_data_as_text(struct grid_data *g, int *ap, wchar_t *cp, int *tap,
 	/* Get the colour for ASCII */
 	if (use_graphics == GRAPHICS_NONE) {
 		grid_get_attr(g, &a);
-		if (g->rage) a = COLOUR_RED + (MAX_COLORS * (a / MAX_COLORS));
+		if (g->rage) a = COLOUR_RED + (MULT_BG * (a / MULT_BG));
 	}
 
 	/* Save the terrain info for the transparency effects */
@@ -299,7 +299,7 @@ void grid_data_as_text(struct grid_data *g, int *ap, wchar_t *cp, int *tap,
 
 			if (use_graphics == GRAPHICS_NONE && OPT(player, highlight_unwary)
 				&& (mon->alertness < ALERTNESS_ALERT)) {
-				a = a + (MAX_COLORS * BG_DARK);
+				a = a + (MULT_BG * BG_DARK);
 			}
 			if (use_graphics != GRAPHICS_NONE
 					&& (a & 0x80)

--- a/src/ui-tutorial.c
+++ b/src/ui-tutorial.c
@@ -158,9 +158,9 @@ static void textui_tutorial_textblock_append_feature_symbol(textblock *tb,
 
 	if (use_graphics == GRAPHICS_NONE && feat_is_wall(feat)) {
 		if (OPT(player, hybrid_walls)) {
-			attr += (MAX_COLORS * BG_DARK);
+			attr += (MULT_BG * BG_DARK);
 		} else if (OPT(player, solid_walls)) {
-			attr += (MAX_COLORS * BG_SAME);
+			attr += (MULT_BG * BG_SAME);
 		}
 	}
 	textblock_append(tb, "('");


### PR DESCRIPTION
Fixes a regression introduced in 1.3.1 by e6a711707bd0057bd9a1a3b9b18bfa58d594e04a .  Also corrects display of wall characters in tutorial textblocks and, for terrain while raged, extracts the background color like the frontends do.