### PR TITLE
Learn equipment's poison/dark resistance from monsters' melee - 1.3 branch

### DIFF
--- a/src/mon-blows.c
+++ b/src/mon-blows.c
@@ -455,6 +455,7 @@ static void melee_effect_handler_DARK(melee_effect_handler_context_t *context)
 	
 	/* Take damage */
 	(void) monster_damage_target(context, true);
+	ident_element(context->p, PROJ_DARK);
 }
 
 /**
@@ -502,6 +503,7 @@ static void melee_effect_handler_POISON(melee_effect_handler_context_t *context)
 	if (player_inc_timed(context->p, TMD_POISONED, context->damage, true,
 			true, true))
 		context->obvious = true;
+	ident_element(context->p, PROJ_POIS);
 }
 
 /**


### PR DESCRIPTION
The handling of dark resistance is for future-proofing: no equipment currenly provides dark resistance but mon-attack.c's elem_bonus() already checks for it.