### PR TITLE
Initialize pseudo in OBJECT_NULL - 1.3 branch

### DIFF
--- a/src/object.h
+++ b/src/object.h
@@ -530,6 +530,7 @@ static struct object const OBJECT_NULL = {
 	.used = 0,
 	.number = 0,
 	.notice = 0,
+	.pseudo = 0,
 	.held_m_idx = 0,
 	.origin = 0,
 	.origin_depth = 0,


### PR DESCRIPTION
That is for consistency:  all other fields have initializers.  Should have no effect in practice since the compiler should set to zero any fields in a static structure variable that were not explicitly initialized.