### PR TITLE
In object descriptions, skip miscellaneous properties without flavor text

### DIFF
--- a/src/obj-info.c
+++ b/src/obj-info.c
@@ -303,7 +303,8 @@ static bool describe_misc_magic(textblock *tb, const bitflag flags[OF_SIZE])
 	for (i = 1; i < OF_MAX; i++) {
 		struct obj_property *prop = lookup_obj_property(OBJ_PROPERTY_FLAG, i);
 		if (!prop) continue;
-		if (of_has(flags, prop->index)) {
+		if (of_has(flags, prop->index) && prop->desc &&
+				!contains_only_spaces(prop->desc)) {
 			textblock_append(tb, "%s.  ", prop->desc);
 			printed = true;
 		}


### PR DESCRIPTION
Examples of those include DIG_1, TWO_HANDED, and HAND_AND_A_HALF.  Resolves https://github.com/NickMcConnell/NarSil/issues/827 .