### PR TITLE
In object descriptions, skip miscellaneous properties without flavor text - 1.3

### DIFF
--- a/src/obj-info.c
+++ b/src/obj-info.c
@@ -307,7 +307,8 @@ static bool describe_misc_magic(textblock *tb, const bitflag flags[OF_SIZE])
 		if (!prop || ((prop->subtype != OFT_MISC) &&
 					  (prop->subtype != OFT_MELEE) &&
 					  (prop->subtype != OFT_BAD))) continue;
-		if (of_has(flags, prop->index)) {
+		if (of_has(flags, prop->index) && prop->desc &&
+				!contains_only_spaces(prop->desc)) {
 			textblock_append(tb, "%s.  ", prop->desc);
 			printed = true;
 		}


### PR DESCRIPTION
Examples of those include DIG_1, TWO_HANDED, and HAND_AND_A_HALF.