### PR TITLE
For object information, skip protections in describe_misc_magic()

### DIFF
--- a/src/obj-info.c
+++ b/src/obj-info.c
@@ -302,7 +302,7 @@ static bool describe_misc_magic(textblock *tb, const bitflag flags[OF_SIZE])
 
 	for (i = 1; i < OF_MAX; i++) {
 		struct obj_property *prop = lookup_obj_property(OBJ_PROPERTY_FLAG, i);
-		if (!prop) continue;
+		if (!prop || prop->subtype == OFT_PROT) continue;
 		if (of_has(flags, prop->index) && prop->desc &&
 				!contains_only_spaces(prop->desc)) {
 			textblock_append(tb, "%s.  ", prop->desc);


### PR DESCRIPTION
Resolves https://github.com/NickMcConnell/NarSil/issues/848 .