### PR TITLE
Decouple light radius from special bonus when smithing; tweak object info

### DIFF
--- a/src/obj-smith.h
+++ b/src/obj-smith.h
@@ -120,6 +120,7 @@ int ps_valid(struct object *obj);
 int ps_max(struct object *obj, bool assume_artistry);
 int ps_min(struct object *obj);
 int pval_valid(struct object *obj);
+int pval_default(struct object *obj);
 int pval_max(struct object *obj);
 int pval_min(struct object *obj);
 int wgt_valid(struct object *obj);

--- a/src/ui-smith.c
+++ b/src/ui-smith.c
@@ -170,7 +170,7 @@ static void reset_smithing_objects(struct object_kind *kind)
 	create_base_object(kind, smith_obj);
 	know_smith_obj();
 	object_copy(smith_obj_backup, smith_obj);
-	pval = pval_valid(smith_obj) ? smith_obj->kind->pval : 0;
+	pval = pval_valid(smith_obj) ? pval_default(smith_obj) : 0;
 }
 
 /**
@@ -516,7 +516,7 @@ static bool tval_action(struct menu *m, const ui_event *event, int oid)
 	/* Set the new value appropriately */
 	if (evt.type == EVT_SELECT) {
 		smith_obj->kind = smithing_svals[menu.cursor];
-		pval = pval_valid(smith_obj) ? smith_obj->kind->pval : 0;
+		pval = pval_valid(smith_obj) ? pval_default(smith_obj) : 0;
 		selected = true;
 	}
 	menu_refresh(smithing_menu, false);
@@ -588,7 +588,7 @@ static int get_smithing_specials(struct object_kind *kind)
 		object_copy(&dummy_body_known, &dummy_body);
 		dummy_body_known.known = NULL;
 		dummy_body.known = &dummy_body_known;
-		pval = pval_valid(&dummy_body) ? dummy_body.pval : 0;
+		pval = pval_valid(&dummy_body) ? pval_default(&dummy_body) : 0;
 		include_pval(&dummy_body);
 		(void)object_difficulty(&dummy_body, &dummy_cost);
 		affordable_specials[count] = smith_affordable(&dummy_body,


### PR DESCRIPTION
The tweaks for object information are:  check for OINFO_SMITH or OINFO_SPOIL in more cases when making the decision to use the fully or partially known values; make OINFO_TERSE orthogonal to OINFO_EGO (and with this change OINFO_SMITH and OINFO_SPOIL) for excluding the kind's base flags from those for the object, use the flags determined by get_known_flags() when describing a light rather than obj->flags, and include the effect of OF_LIGHT when displaying the radius for a light.

Resolves https://github.com/NickMcConnell/NarSil/issues/852 .