### PR TITLE
Decouple light radius from special bonus when smithing; tweak object info - 1.3

### DIFF
--- a/src/obj-info.c
+++ b/src/obj-info.c
@@ -535,14 +535,15 @@ static void get_known_flags(const struct object *obj, const oinfo_detail_t mode,
 							bitflag flags[OF_SIZE])
 {
 	/* Grab the object flags */
-	if (mode & OINFO_EGO) {
-			object_flags(obj, flags);
+	if ((mode & OINFO_EGO) || (mode & OINFO_SPOIL)
+			|| (mode & OINFO_SMITH)) {
+		object_flags(obj, flags);
 	} else {
 		object_flags_known(obj, flags);
-
-		/* Don't include base flags when terse */
-		if (mode & OINFO_TERSE)
-			of_diff(flags, obj->kind->base->flags);
+	}
+	/* Don't include base flags when terse */
+	if (mode & OINFO_TERSE) {
+		of_diff(flags, obj->kind->base->flags);
 	}
 }
 
@@ -559,7 +560,8 @@ static void get_known_elements(const struct object *obj,
 	/* Grab the element info */
 	for (i = 0; i < ELEM_MAX; i++) {
 		/* Report fake egos or known element info */
-		if (object_is_known(obj) || (mode & OINFO_SPOIL))
+		if (object_is_known(obj) || (mode & OINFO_SPOIL)
+				|| (mode & OINFO_SMITH))
 			el_info[i].res_level = obj->el_info[i].res_level;
 		else
 			el_info[i].res_level = 0;
@@ -591,7 +593,8 @@ static void get_known_elements(const struct object *obj,
  * includes it not actually being a light source).
  */
 static bool obj_known_light(const struct object *obj, oinfo_detail_t mode,
-							int *intensity, bool *uses_fuel, int *refuel_turns)
+		const bitflag flags[OF_MAX], int *intensity, bool *uses_fuel,
+		int *refuel_turns)
 {
 	bool no_fuel;
 	bool is_light = tval_is_light(obj);
@@ -599,15 +602,21 @@ static bool obj_known_light(const struct object *obj, oinfo_detail_t mode,
 	if (!is_light)
 		return false;
 
-	/* Work out intensity */
-	*intensity = obj->pval;
+	/*
+	 * Work out intensity; smithing can use pval for the special bonus so
+	 * look at the kind's pval for the radius in that case
+	 */
+	*intensity = (mode & OINFO_SMITH) ? obj->kind->pval : obj->pval;
+	if (of_has(flags, OF_LIGHT)) {
+		++*intensity;
+	}
 
 	/* Prevent unidentified objects (especially artifact lights) from showing
 	 * bad intensity and refueling info. */
 	if (*intensity == 0)
 		return false;
 
-	no_fuel = of_has(obj->flags, OF_NO_FUEL) ? true : false;
+	no_fuel = of_has(flags, OF_NO_FUEL) ? true : false;
 
 	if (no_fuel || obj->artifact) {
 		*uses_fuel = false;
@@ -615,7 +624,7 @@ static bool obj_known_light(const struct object *obj, oinfo_detail_t mode,
 		*uses_fuel = true;
 	}
 
-	if (is_light && of_has(obj->flags, OF_TAKES_FUEL)) {
+	if (is_light && of_has(flags, OF_TAKES_FUEL)) {
 		*refuel_turns = z_info->fuel_lamp;
 	} else {
 		*refuel_turns = 0;
@@ -628,14 +637,14 @@ static bool obj_known_light(const struct object *obj, oinfo_detail_t mode,
  * Describe things that look like lights.
  */
 static bool describe_light(textblock *tb, const struct object *obj,
-						   oinfo_detail_t mode)
+		oinfo_detail_t mode, const bitflag flags[OF_SIZE])
 {
 	int intensity = 0;
 	bool uses_fuel = false;
 	int refuel_turns = 0;
 	bool terse = mode & OINFO_TERSE ? true : false;
 
-	if (!obj_known_light(obj, mode, &intensity, &uses_fuel, &refuel_turns))
+	if (!obj_known_light(obj, mode, flags, &intensity, &uses_fuel, &refuel_turns))
 		return false;
 
 	if (tval_is_light(obj)) {
@@ -818,7 +827,7 @@ static textblock *object_info_out(const struct object *obj, int mode)
 	if (describe_abilities(tb, obj, mode)) something = true;
 	if (describe_archery(tb, obj)) something = true;
 	if (describe_throwing(tb, obj)) something = true;
-	if (describe_light(tb, obj, mode)) something = true;
+	if (describe_light(tb, obj, mode, flags)) something = true;
 	if (describe_ignores(tb, el_info)) something = true;
 	if (describe_hates(tb, el_info)) something = true;
 	if (something) textblock_append(tb, "\n");

--- a/src/obj-smith.c
+++ b/src/obj-smith.c
@@ -333,11 +333,33 @@ int pval_valid(struct object *obj)
 
 
 /**
+ * Determines the default (starting) pval for an item.
+ */
+int pval_default(struct object *obj)
+{
+	/*
+	 * Do not want to use a light's radius as the basis for the special
+	 * value during smithing.
+	 */
+	int pval = tval_is_light(obj) ? 0 : obj->kind->pval;
+
+	if (obj->ego && obj->ego->pval > 0) {
+		pval += object_is_cursed(obj) ? -1 : 1;
+	}
+	return pval;
+}
+
+
+/**
  * Determines the maximum legal pval for an item.
  */
 int pval_max(struct object *obj)
 {
-	int pval = obj->kind->pval;
+	/*
+	 * Do not want to use a light's radius as the basis for the special
+	 * value during smithing.
+	 */
+	int pval = tval_is_light(obj) ? 0 : obj->kind->pval;
 
 	/* Artefacts have pvals that are mostly unlimited  */
 	if (obj->artifact) {
@@ -365,7 +387,11 @@ int pval_max(struct object *obj)
  */
 int pval_min(struct object *obj)
 {
-	int pval = obj->kind->pval;
+	/*
+	 * Do not want to use a light's radius as the basis for the special
+	 * value during smithing.
+	 */
+	int pval = tval_is_light(obj) ? 0 : obj->kind->pval;
 
 	/* Artefacts have pvals that are mostly unlimited  */
 	if (obj->artifact) {
@@ -380,7 +406,7 @@ int pval_min(struct object *obj)
 		if (object_is_cursed(obj)) {
 			if (obj->ego->pval > 0) pval -= obj->ego->pval;
 		} else if (obj->ego->pval > 0) {
-			pval -= 1;
+			pval += 1;
 		}
 	}
 
@@ -1069,9 +1095,16 @@ void create_base_object(struct object_kind *kind, struct object *obj)
 	/* Set the pval to 1 if needed (and evasion/accuracy for rings) */
 	set_base_values(obj);
 
-	/* Lanterns are empty */
-	if (tval_is_light(obj) && of_has(obj->flags, OF_TAKES_FUEL)) {
-		obj->timeout = 0;
+	if (tval_is_light(obj)) {
+		/*
+		 * While smithing, use pval for the special bonus rather than
+		 * light radius; restore it when finalizing the smithed item
+		 */
+		obj->pval = 0;
+		/* Lanterns are empty */
+		if (of_has(obj->flags, OF_TAKES_FUEL)) {
+			obj->timeout = 0;
+		}
 	}
 
 	/* Create arrows by the two dozen */
@@ -1412,8 +1445,14 @@ static void create_smithing_item(struct object *obj, struct smithing_cost *cost)
 		obj->artifact = &a_info[aidx];
 	}
 
-	/* Create the object */
+	/*
+	 * Create the object; since lights use pval for the radius, reset
+	 * that to what the kind has
+	 */
 	object_copy(created, obj);
+	if (tval_is_light(created)) {
+		created->pval = created->kind->pval;
+	}
 	
 	/* Identify the object */
 	object_flavor_aware(player, created);

--- a/src/obj-smith.h
+++ b/src/obj-smith.h
@@ -120,6 +120,7 @@ int ps_valid(struct object *obj);
 int ps_max(struct object *obj, bool assume_artistry);
 int ps_min(struct object *obj);
 int pval_valid(struct object *obj);
+int pval_default(struct object *obj);
 int pval_max(struct object *obj);
 int pval_min(struct object *obj);
 int wgt_valid(struct object *obj);

--- a/src/ui-smith.c
+++ b/src/ui-smith.c
@@ -154,7 +154,7 @@ static void reset_smithing_objects(struct object_kind *kind)
 	create_base_object(kind, smith_obj);
 	object_know(smith_obj);
 	object_copy(smith_obj_backup, smith_obj);
-	pval = pval_valid(smith_obj) ? smith_obj->kind->pval : 0;
+	pval = pval_valid(smith_obj) ? pval_default(smith_obj) : 0;
 }
 
 /**
@@ -495,7 +495,7 @@ static bool tval_action(struct menu *m, const ui_event *event, int oid)
 	/* Set the new value appropriately */
 	if (evt.type == EVT_SELECT) {
 		smith_obj->kind = smithing_svals[menu.cursor];
-		pval = pval_valid(smith_obj) ? smith_obj->kind->pval : 0;
+		pval = pval_valid(smith_obj) ? pval_default(smith_obj) : 0;
 		selected = true;
 	}
 	menu_refresh(smithing_menu, false);
@@ -565,7 +565,7 @@ static int get_smithing_specials(struct object_kind *kind)
 		object_copy(&dummy_body, smith_obj);
 		create_special(&dummy_body, ego);
 		object_know(&dummy_body);
-		pval = pval_valid(&dummy_body) ? dummy_body.pval : 0;
+		pval = pval_valid(&dummy_body) ? pval_valid(&dummy_body) : 0;
 		include_pval(&dummy_body);
 		(void)object_difficulty(&dummy_body, &dummy_cost);
 		affordable_specials[count] = smith_affordable(&dummy_body,


### PR DESCRIPTION
The tweaks for object information are:  check for OINFO_SMITH or OINFO_SPOIL in more cases when making the decision to use the fully or partially known values; make OINFO_TERSE orthogonal to OINFO_EGO (and with this change OINFO_SMITH and OINFO_SPOIL) for excluding the kind's base flags from those for the object, use the flags determined by get_known_flags() when describing a light rather than obj->flags, and include the effect of OF_LIGHT when displaying the radius for a light.

Resolves https://github.com/NickMcConnell/NarSil/issues/852 for the 1.3 branch.