### PR TITLE
Plug potential memory leak in 1.3 branch's display_object_kind_recall()

### DIFF
--- a/src/ui-object.c
+++ b/src/ui-object.c
@@ -1232,6 +1232,7 @@ void display_object_kind_recall(struct object_kind *kind)
 	object_prep(&object, kind, 0, EXTREMIFY);
 
 	display_object_recall(&object);
+	object_wipe(&object);
 }
 
 /**


### PR DESCRIPTION
There would only be a leak if the kind specified slays, brands, or an ability list.  In the current game, no kinds do so.