### PR TITLE
Remove unused smithing difficulties from slay.txt and brand.txt - 1.3

### DIFF
--- a/lib/gamedata/brand.txt
+++ b/lib/gamedata/brand.txt
@@ -7,7 +7,7 @@
 # that element in projection.txt.  Changes to the code will require changes to
 # the other data files (artefact.txt, object_base.txt, object_property.txt,
 # and special.txt) that may have used the code.  Changes to dice, vuln-dice,
-# smith-difficulty, resist-flag, and vuln-flag can affect balance.
+# resist-flag, and vuln-flag can affect balance.
 
 # Fields:
 # code: code for brand to use in other data files (artefact.txt,
@@ -17,7 +17,6 @@
 # vuln-dice: number of bonus dice given by the brand if the monster is
 #     especially vulnerable
 # desc: description used when a susceptible monster is hit
-# smith-difficulty: difficulty cost to smith an item with this brand
 # resist-flag: monster race flag for resistance to the brand element; has
 #     to match the first argument to one of the RF() macros in
 #     list-mon-race-flags.h
@@ -35,7 +34,6 @@ name:fire
 dice:1
 vuln-dice:1
 desc:burns {name} with an inner fire
-smith-difficulty:24
 resist-flag:RES_FIRE
 vuln-flag:HURT_FIRE
 
@@ -44,7 +42,6 @@ name:cold
 dice:1
 vuln-dice:1
 desc:freezes {name}
-smith-difficulty:20
 resist-flag:RES_COLD
 vuln-flag:HURT_COLD
 
@@ -52,5 +49,4 @@ code:POIS_1
 name:poison
 dice:1
 desc:poisons {name}
-smith-difficulty:16
 resist-flag:RES_POIS

--- a/lib/gamedata/slay.txt
+++ b/lib/gamedata/slay.txt
@@ -6,8 +6,8 @@
 # same type of creature should all use the same name.  Changes to the
 # code will require changes to the other data files (artefact.txt,
 # object_base.txt, object_property.txt, and special.txt) that may have used
-# the code.  Changes to the race-flag, dice, and smith-difficulty can affect
-# balance.  The race flag has to match one in list-mon-race-flags.h
+# the code.  Changes to the race-flag and dice can affect balance.  The race
+# flag has to match one in list-mon-race-flags.h
 
 # Fields:
 # code: code for slay to use in other data files (artefact.txt,
@@ -19,46 +19,38 @@
 #     list-mon-race-flags.h; can not be used with another race-flag directive
 #     for the same slay
 # dice: number of bonus dice given by the slay
-# smith-difficulty: difficulty cost to smith an item with this slay
 
 code:ORC_1
 name:orcs
 race-flag:ORC
 dice:1
-smith-difficulty:5
 
 code:WOLF_1
 name:wolves
 race-flag:WOLF
 dice:1
-smith-difficulty:6
 
 code:SPIDER_1
 name:spiders
 race-flag:SPIDER
 dice:1
-smith-difficulty:6
 
 code:UNDEAD_1
 name:undead
 race-flag:UNDEAD
 dice:1
-smith-difficulty:6
 
 code:RAUKO_1
 name:raukar
 race-flag:RAUKO
 dice:1
-smith-difficulty:7
 
 code:DRAGON_1
 name:dragons
 race-flag:DRAGON
 dice:1
-smith-difficulty:7
 
 code:TROLL_1
 name:trolls
 race-flag:TROLL
 dice:1
-smith-difficulty:5

--- a/src/obj-init.c
+++ b/src/obj-init.c
@@ -800,16 +800,6 @@ static enum parser_error parse_slay_dice(struct parser *p) {
 	return PARSE_ERROR_NONE;
 }
 
-static enum parser_error parse_slay_smith_difficulty(struct parser *p) {
-	struct slay *slay = parser_priv(p);
-
-	if (!slay) {
-		return PARSE_ERROR_MISSING_RECORD_HEADER;
-	}
-	slay->smith_difficulty = parser_getuint(p, "diff");
-	return PARSE_ERROR_NONE;
-}
-
 static struct parser *init_parse_slay(void) {
 	struct parser *p = parser_new();
 	parser_setpriv(p, NULL);
@@ -817,7 +807,6 @@ static struct parser *init_parse_slay(void) {
 	parser_reg(p, "name str name", parse_slay_name);
 	parser_reg(p, "race-flag sym flag", parse_slay_race_flag);
 	parser_reg(p, "dice uint dice", parse_slay_dice);
-	parser_reg(p, "smith-difficulty uint diff", parse_slay_smith_difficulty);
 	return p;
 }
 
@@ -936,16 +925,6 @@ static enum parser_error parse_brand_vuln_dice(struct parser *p) {
 	return PARSE_ERROR_NONE;
 }
 
-static enum parser_error parse_brand_smith_difficulty(struct parser *p) {
-	struct brand *brand = parser_priv(p);
-
-	if (!brand) {
-		return PARSE_ERROR_MISSING_RECORD_HEADER;
-	}
-	brand->smith_difficulty = parser_getuint(p, "diff");
-	return PARSE_ERROR_NONE;
-}
-
 static enum parser_error parse_brand_resist_flag(struct parser *p) {
 	int flag;
 	struct brand *brand = parser_priv(p);
@@ -984,7 +963,6 @@ static struct parser *init_parse_brand(void) {
 	parser_reg(p, "desc str desc", parse_brand_desc);
 	parser_reg(p, "dice uint dice", parse_brand_dice);
 	parser_reg(p, "vuln-dice uint dice", parse_brand_vuln_dice);
-	parser_reg(p, "smith-difficulty uint diff", parse_brand_smith_difficulty);
 	parser_reg(p, "resist-flag sym flag", parse_brand_resist_flag);
 	parser_reg(p, "vuln-flag sym flag", parse_brand_vuln_flag);
 	return p;

--- a/src/object.h
+++ b/src/object.h
@@ -96,7 +96,6 @@ struct brand {
 	int vuln_flag;
 	int dice;
 	int vuln_dice;
-	int smith_difficulty;
 	struct brand *next;
 };
 
@@ -108,7 +107,6 @@ struct slay {
 	char *name;
 	int race_flag;
 	int dice;
-	int smith_difficulty;
 	struct slay *next;
 };
 

--- a/src/tests/parse/brand.c
+++ b/src/tests/parse/brand.c
@@ -42,8 +42,6 @@ static int test_missing_record_header0(void *state) {
 	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
 	r = parser_parse(p, "vuln-dice:2");
 	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
-	r = parser_parse(p, "smith-difficulty:24");
-	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
 	r = parser_parse(p, "resist-flag:RES_FIRE");
 	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
 	r = parser_parse(p, "vuln-flag:HURT_FIRE");
@@ -67,7 +65,6 @@ static int test_code0(void *state) {
 	eq(b->vuln_flag, 0);
 	eq(b->dice, 0);
 	eq(b->vuln_dice, 0);
-	eq(b->smith_difficulty, 0);
 	ok;
 }
 
@@ -132,18 +129,6 @@ static int test_vuln_dice0(void *state) {
 	ok;
 }
 
-static int test_smith_difficulty0(void *state) {
-	struct parser *p = (struct parser*) state;
-	enum parser_error r = parser_parse(p, "smith-difficulty:24");
-	struct brand *b;
-
-	eq(r, PARSE_ERROR_NONE);
-	b = (struct brand*) parser_priv(p);
-	notnull(b);
-	eq(b->smith_difficulty, 24);
-	ok;
-}
-
 static int test_resist_flag0(void *state) {
 	struct parser *p = (struct parser*) state;
 	enum parser_error r = parser_parse(p, "resist-flag:RES_FIRE");
@@ -192,7 +177,6 @@ static int test_combined0(void *state) {
 		"dice:1",
 		"vuln-dice:2",
 		"desc:freezes {name}",
-		"smith-difficulty:20",
 		"resist-flag:RES_COLD",
 		"vuln-flag:HURT_COLD"
 	};
@@ -214,7 +198,6 @@ static int test_combined0(void *state) {
 	require(streq(b->desc, "freezes {name}"));
 	eq(b->dice, 1);
 	eq(b->vuln_dice, 2);
-	eq(b->smith_difficulty, 20);
 	eq(b->resist_flag, RF_RES_COLD);
 	eq(b->vuln_flag, RF_HURT_COLD);
 	ok;
@@ -234,7 +217,6 @@ struct test tests[] = {
 	{ "desc0", test_desc0 },
 	{ "dice0", test_dice0 },
 	{ "vuln_dice0", test_vuln_dice0 },
-	{ "smith_difficulty0", test_smith_difficulty0 },
 	{ "resist_flag0", test_resist_flag0 },
 	{ "resist_flag_bad0", test_resist_flag_bad0 },
 	{ "vuln_flag0", test_vuln_flag0 },

--- a/src/tests/parse/slay.c
+++ b/src/tests/parse/slay.c
@@ -41,8 +41,6 @@ static int test_missing_record_header0(void *state)
 	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
 	r = parser_parse(p, "dice:1");
 	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
-	r = parser_parse(p, "smith-difficulty:5");
-	eq(r, PARSE_ERROR_MISSING_RECORD_HEADER);
 	ok;
 }
 
@@ -59,7 +57,6 @@ static int test_code0(void *state) {
 	null(s->name);
 	eq(s->race_flag, 0);
 	eq(s->dice, 0);
-	eq(s->smith_difficulty, 0);
 	ok;
 }
 
@@ -112,26 +109,13 @@ static int test_dice0(void *state) {
 	ok;
 }
 
-static int test_smith_difficulty0(void *state) {
-	struct parser *p = (struct parser*) state;
-	enum parser_error r = parser_parse(p, "smith-difficulty:5");
-	struct slay *s;
-
-	eq(r, PARSE_ERROR_NONE);
-	s = (struct slay*) parser_priv(p);
-	notnull(s);
-	eq(s->smith_difficulty, 5);
-	ok;
-}
-
 static int test_combined0(void *state) {
 	struct parser *p = (struct parser*) state;
 	const char *lines[] = {
 		"code:SPIDER_1",
 		"name:spiders",
 		"race-flag:SPIDER",
-		"dice:1",
-		"smith-difficulty:6"
+		"dice:1"
 	};
 	struct slay *s;
 	int i;
@@ -149,7 +133,6 @@ static int test_combined0(void *state) {
 	require(streq(s->name, "spiders"));
 	eq(s->race_flag, RF_SPIDER);
 	eq(s->dice, 1);
-	eq(s->smith_difficulty, 6);
 	ok;
 }
 
@@ -167,7 +150,6 @@ struct test tests[] = {
 	{ "race_flag0", test_race_flag0 },
 	{ "race_flag_bad0", test_race_flag_bad0 },
 	{ "dice0", test_dice0 },
-	{ "smith_difficulty0", test_smith_difficulty0 },
 	{ "combined0", test_combined0 },
 	{ NULL, NULL }
 };


### PR DESCRIPTION
All the smithing data for properties comes from object_property.txt.