### PR TITLE
Mimic Sil: cost is zero, not negative, for a negative modifier - 1.3

### DIFF
--- a/src/obj-smith.c
+++ b/src/obj-smith.c
@@ -694,6 +694,7 @@ static void dif_mod(int value, int positive_base, int *dif_inc)
  */
 static void adjust_smithing_cost(int diff, struct obj_property *prop, struct smithing_cost *smithing_cost)
 {
+	if (diff <= 0) return;
 	switch (prop->smith_cost_type) {
 		case SMITH_COST_STR: smithing_cost->stat[STAT_STR] += diff * prop->smith_cost; break;
 		case SMITH_COST_DEX: smithing_cost->stat[STAT_DEX] += diff * prop->smith_cost; break;


### PR DESCRIPTION
See cmd4.c:2699,2703,2718 in Sil 1.3.  Resolves https://github.com/NickMcConnell/NarSil/issues/861 for the 1.3 branch.