### PR TITLE
Correct array size in obj_known_light() declaration - 1.3

### DIFF
--- a/src/obj-info.c
+++ b/src/obj-info.c
@@ -593,7 +593,7 @@ static void get_known_elements(const struct object *obj,
  * includes it not actually being a light source).
  */
 static bool obj_known_light(const struct object *obj, oinfo_detail_t mode,
-		const bitflag flags[OF_MAX], int *intensity, bool *uses_fuel,
+		const bitflag flags[OF_SIZE], int *intensity, bool *uses_fuel,
 		int *refuel_turns)
 {
 	bool no_fuel;


### PR DESCRIPTION
Incorrect size was introduced in 6320d461b939cf2087bebbfa8333f3265cae45e7 .  Resolves https://github.com/NickMcConnell/NarSil/issues/869 for the 1.3 branch.