### PR TITLE
Better mimic Sil 1.3 egos/smithing for base objects with modifiers - 1.3

### DIFF
--- a/lib/gamedata/object.txt
+++ b/lib/gamedata/object.txt
@@ -756,7 +756,8 @@ attack:-3:2d2
 defence:0:0d0
 alloc:5:3
 alloc:12:3
-flags:DIG_1 | TWO_HANDED
+flags:TWO_HANDED
+values:TUNNEL[1]
 desc:It can be equipped as a weapon and allows you to dig through rubble.
 
 
@@ -772,7 +773,8 @@ cost:700
 attack:-5:5d2
 defence:0:0d0
 alloc:10:3
-flags:DIG_2 | TWO_HANDED
+flags:TWO_HANDED
+values:TUNNEL[2]
 desc:It can be equipped as a weapon and (usually) allows you to dig through
 desc: rubble or quartz.
 

--- a/lib/gamedata/object_property.txt
+++ b/lib/gamedata/object_property.txt
@@ -7,23 +7,59 @@
 # id-type: how a property is identified, currently only used by flags
 # code: a code for the object property, which is used to associate it with its
 #       index among the other properties of that type
+# smith-cat: is the name for the category in smithing's Artifice menu that
+#            will include the property; if smith-cat is omitted for a property
+#            the property can not be added to a smithed artifact; the name
+#            of the category must be stat, sustain, skill, melee, slay,
+#            resist, curse, or misc
+# smith-difficulty: sets the additional smithing difficulty, an integer, to
+#                   include this property on a smithed item; if the property is
+#                   a flag, resist, slay, or brand, the difficulty is simply
+#                   added to the total difficulty for the item when the item
+#                   has the property; if the property is a stat, skill, or
+#                   mod, the additional difficulty from adjusting the
+#                   stat/skill/mod by v is zero if v is less than or equal to
+#                   zero or v * difficulty value + (1 +
+#                   ((difficulty value - 1) / 5)) * v * (v - 1) when v is
+#                   greater than zero; if smith-difficulty is omitted for
+#                   a property, adding the property does not increase the
+#                   difficulty of the smithed item; note that a smithed
+#                   item could get a property from the base item, an
+#                   enchantment (i.e. from special.txt), or from a property
+#                   added for an artifact so the difficulty could be relevant
+#                   even if smith-cat is not set
+# smith-cost: sets the cost, in addition to the added difficulty for including
+#             the property on a smithed item; if smith-cost is omitted for a
+#             property, including the property on a smithed item incurs no
+#             additional cost; takes two parameters; the first is the name
+#             of the attribute that incurs the cost; that name must either
+#             be the name of a statistic (STR, DEX, CON, or GRA) or EXP; the
+#             latter indicates that the cost is extracted from the player's
+#             unspent experience pool; the second parameter is the integer
+#             value of the cost; for a flag, resist, slay, or brand, the cost
+#             is used as is when the property is included; if the property is
+#             a stat, skill, or mod the cost for adjusting the stat/skill/mod
+#             by v is v times the cost
+# smith-exclude-base: sets whether the additional difficulty or cost for
+#                     including a property on a smithed non-jewelry item will
+#                     include whether or not the base item has the property;
+#                     the costs and difficulty of smithed jewelry always
+#                     includes the properties of the base item; if a
+#                     property has smith-exclude-base:yes, the difficulty and
+#                     cost will not be increased by the presence of the
+#                     property on the base item (for a stat, skill, or mod,
+#                     additional levels beyond what is present on the base
+#                     item can affect the difficulty and cost); if a property
+#                     has smith-exclude-base:no or does not specify
+#                     smith-exclude-base, the presence of the property
+#                     on the base item will be included in the difficulty and
+#                     cost
 # adjective: adjective describing the property as a player attribute, currently
 #            only used by stats
 # neg-adjective: adjective describing the opposite of the property as a player
 #                attribute, currently only used by stats
 # msg: message printed on noticing a property, currently used for flags which
 #      are identified after time or on an effect
-# bindui: Binds the property to a user interface element in ui_entry.txt.
-#         Takes two additional integer parameters.  The first, if nonzero,
-#         specifies that the value bound be passed as an auxiliary value (a
-#         sustain for a stat, for instance).  The second is optional and is
-#         the value to pass when the object has the property (either on as a
-#         flag or a nonzero value for a modifier or resistance).  When not set,
-#         the value (0 for off flag, 1 for on flag, value for modifier,
-#         resistance level for a resistance) is sent.  bindui is currently only
-#         used for parts of the second character screen and the equippable
-#         comparison.  This field can appear multiple times to bind a property
-#         to more than one user interface element.
 # desc: an extra piece of descriptive text used in object information
 
 name:strength
@@ -128,6 +164,7 @@ code:TUNNEL
 smith-cat:melee
 smith-difficulty:10
 smith-cost:STR:1
+smith-exclude-base:yes
 
 name:light
 type:flag
@@ -136,6 +173,7 @@ code:LIGHT
 smith-cat:misc
 smith-difficulty:8
 smith-cost:GRA:1
+smith-exclude-base:yes
 desc:Lights the dungeon around you
 
 name:sustain strength
@@ -146,6 +184,7 @@ code:SUST_STR
 smith-cat:sustain
 smith-difficulty:3
 smith-cost:STR:1
+smith-exclude-base:yes
 msg:Your {name} glows.
 
 name:sustain dexterity
@@ -156,6 +195,7 @@ code:SUST_DEX
 smith-cat:sustain
 smith-difficulty:3
 smith-cost:DEX:1
+smith-exclude-base:yes
 msg:Your {name} glows.
 
 name:sustain constitution
@@ -166,6 +206,7 @@ code:SUST_CON
 smith-cat:sustain
 smith-difficulty:3
 smith-cost:CON:1
+smith-exclude-base:yes
 msg:Your {name} glows.
 
 name:sustain grace
@@ -176,6 +217,7 @@ code:SUST_GRA
 smith-cat:sustain
 smith-difficulty:3
 smith-cost:GRA:1
+smith-exclude-base:yes
 msg:Your {name} glows.
 
 name:protection from fear
@@ -185,6 +227,7 @@ subtype:protection
 id-type:on effect
 smith-cat:resist
 smith-difficulty:3
+smith-exclude-base:yes
 msg:Your {name} fills you with courage.
 desc:fear
 
@@ -195,6 +238,7 @@ subtype:protection
 id-type:on effect
 smith-cat:resist
 smith-difficulty:6
+smith-exclude-base:yes
 msg:Your {name} protects your sight.
 desc:blindness
 
@@ -205,6 +249,7 @@ subtype:protection
 id-type:on effect
 smith-cat:resist
 smith-difficulty:6
+smith-exclude-base:yes
 msg:Your {name} fills you with calm.
 desc:confusion
 
@@ -215,6 +260,7 @@ subtype:protection
 id-type:on effect
 smith-cat:resist
 smith-difficulty:3
+smith-exclude-base:yes
 msg:Your {name} fills you with calm.
 desc:stunning
 
@@ -225,6 +271,7 @@ subtype:protection
 id-type:on effect
 smith-cat:resist
 smith-difficulty:3
+smith-exclude-base:yes
 msg:Your {name} protects your sight.
 desc:hallucination
 
@@ -235,6 +282,7 @@ id-type:timed
 code:SLOW_DIGEST
 smith-cat:misc
 smith-difficulty:4
+smith-exclude-base:yes
 msg:You realise your {name} is slowing your metabolism.
 desc:Reduces your need for food
 
@@ -246,6 +294,7 @@ code:REGEN
 smith-cat:misc
 smith-difficulty:8
 smith-cost:CON:1
+smith-exclude-base:yes
 msg:You note that your {name} is speeding up your recovery.
 desc:Speeds your regeneration (which also increases your hunger)
 
@@ -256,6 +305,7 @@ id-type:on wield
 code:SEE_INVIS
 smith-cat:misc
 smith-difficulty:8
+smith-exclude-base:yes
 desc:Grants the ability to see invisible things
 
 name:free action
@@ -265,6 +315,7 @@ id-type:on effect
 code:FREE_ACT
 smith-cat:misc
 smith-difficulty:8
+smith-exclude-base:yes
 msg:Your {name} glows softly.
 desc:Grants you freedom of movement
 
@@ -276,6 +327,7 @@ code:SPEED
 smith-cat:misc
 smith-difficulty:30
 smith-cost:CON:5
+smith-exclude-base:yes
 msg:Your {name} quickens your steps.
 desc:Grants you great speed
 
@@ -287,6 +339,7 @@ code:RADIANCE
 smith-cat:misc
 smith-difficulty:8
 smith-cost:GRA:1
+smith-exclude-base:yes
 msg:Your {name} glows.
 desc:Creates a path of light
 
@@ -298,6 +351,7 @@ code:SHARPNESS
 smith-cat:melee
 smith-difficulty:20
 smith-cost:STR:2
+smith-exclude-base:yes
 desc:Sharp
 slay-msg:cuts deeply
 
@@ -317,6 +371,7 @@ code:VAMPIRIC
 smith-cat:melee
 smith-difficulty:10
 smith-cost:STR:2
+smith-exclude-base:yes
 desc:Vampiric
 slay-msg:drains life from {name}
 
@@ -345,6 +400,7 @@ id-type:timed
 code:DANGER
 smith-cat:curse
 smith-difficulty:-5
+smith-exclude-base:yes
 desc:Makes you encounter more dangerous creatures (even when not worn)
 
 name:darkness
@@ -354,6 +410,7 @@ id-type:on wield
 code:DARKNESS
 smith-cat:curse
 smith-difficulty:-5
+smith-exclude-base:yes
 desc:Creates an unnatural darkness
 
 name:cowardice
@@ -363,6 +420,7 @@ id-type:on wield
 code:COWARDICE
 smith-cat:curse
 smith-difficulty:0
+smith-exclude-base:yes
 desc:Causes you to panic in combat
 
 name:hunger
@@ -372,6 +430,7 @@ id-type:on wield
 code:HUNGER
 smith-cat:curse
 smith-difficulty:0
+smith-exclude-base:yes
 desc:Increases your hunger
 
 name:wrath
@@ -381,6 +440,7 @@ id-type:timed
 code:AGGRAVATE
 smith-cat:curse
 smith-difficulty:0
+smith-exclude-base:yes
 msg:You notice your {name} aggravating things around you.
 desc:Enrages nearby creatures
 
@@ -391,6 +451,7 @@ id-type:timed
 code:HAUNTED
 smith-cat:curse
 smith-difficulty:0
+smith-exclude-base:yes
 msg:You sense your {name} is draining your life.
 desc:Draws wraiths to your level
 
@@ -401,6 +462,7 @@ id-type:on wield
 code:CURSED
 smith-cat:curse
 smith-difficulty:0
+smith-exclude-base:yes
 desc:Is cursed
 
 name:power 1 digging

--- a/src/obj-init.c
+++ b/src/obj-init.c
@@ -2933,6 +2933,23 @@ static enum parser_error parse_object_property_smith_cost(struct parser *p) {
 	return PARSE_ERROR_NONE;
 }
 
+static enum parser_error parse_object_property_smith_exclude_base(struct parser *p) {
+	struct obj_property *prop = parser_priv(p);
+	const char *yesno = parser_getstr(p, "yesno");
+
+	if (!prop) {
+		return PARSE_ERROR_MISSING_RECORD_HEADER;
+	}
+	if (streq(yesno, "yes")) {
+		prop->smith_exclude_base = true;
+	} else if (streq(yesno, "no")) {
+		prop->smith_exclude_base = false;
+	} else {
+		return PARSE_ERROR_INVALID_OPTION;
+	}
+	return PARSE_ERROR_NONE;
+}
+
 static enum parser_error parse_object_property_adjective(struct parser *p) {
 	struct obj_property *prop = parser_priv(p);
 	const char *adj = parser_getstr(p, "adj");
@@ -3003,6 +3020,8 @@ static struct parser *init_parse_object_property(void) {
 			   parse_object_property_smith_diff);
 	parser_reg(p, "smith-cost sym type int cost",
 			   parse_object_property_smith_cost);
+	parser_reg(p, "smith-exclude-base str yesno",
+			   parse_object_property_smith_exclude_base);
 	parser_reg(p, "type str type", parse_object_property_type);
 	parser_reg(p, "subtype str subtype", parse_object_property_subtype);
 	parser_reg(p, "id-type str id", parse_object_property_id_type);

--- a/src/obj-make.c
+++ b/src/obj-make.c
@@ -296,6 +296,8 @@ void ego_apply_magic(struct object *obj, bool smithing)
 
 	/* Bonuses apply differently for smithed objects */
 	if (smithing) {
+		bool flip_sign;
+
 		/* Apply extra ego bonuses */
 		if (ego->att) obj->att += 1;
 		if (ego->evn) obj->evn += 1;
@@ -304,22 +306,68 @@ void ego_apply_magic(struct object *obj, bool smithing)
 		if (ego->pd) obj->pd += 1;
 		if (ego->ps) obj->ps += 1;
 
+		obj->pval = extract_kind_pval(obj->kind, AVERAGE, &flip_sign);
 		if (ego->pval > 0) {
-			if (of_has(ego->flags, OF_CURSED)) {
-				obj->pval = -1;
-			} else {
-				obj->pval = 1;
+			obj->pval += (of_has(ego->flags, OF_CURSED)) ? -1 : 1;
+		}
+
+		/*
+		 * Mark any modifiers that are changed by the ego or can be
+		 * non-zero in the base object with a non-zero value so that
+		 * smithing knows which modifiers must change when the special
+		 * bonus is changed.  The value used will be negative when
+		 * smithing should set that modifier to the value of the
+		 * special bonus with its sign flipped.
+		 */
+		for (i = 0; i < OBJ_MOD_MAX; i++) {
+			int min_m = randcalc(obj->kind->modifiers[i],
+				0, MINIMISE);
+			int max_m = randcalc(obj->kind->modifiers[i],
+				z_info->dun_depth, MAXIMISE);
+
+			if (min_m == SPECIAL_VALUE) {
+				min_m = randcalc(obj->kind->special1,
+					0, MINIMISE);
+				if (!min_m && obj->kind->special2) {
+					min_m = obj->kind->special2;
+				}
+			}
+			if (max_m == SPECIAL_VALUE) {
+				max_m = randcalc(obj->kind->special1,
+					z_info->dun_depth, MAXIMISE);
+				if (!max_m && obj->kind->special2) {
+					max_m = obj->kind->special2;
+				}
+			}
+			if (min_m || max_m) {
+				if (min_m >= 0) {
+					obj->modifiers[i] = MAX(1, obj->pval);
+				} else if (max_m > 0) {
+					if (obj->pval) {
+						obj->modifiers[i] =
+							(max_m >= -min_m) ?
+							obj->pval : -obj->pval;
+					} else {
+						obj->modifiers[i] =
+							(max_m >= -min_m) ?
+							1 : -1;
+					}
+				} else {
+					obj->modifiers[i] = MIN(-1, -obj->pval);
+				}
+				if (flip_sign) {
+					obj->modifiers[i] *= -1;
+				}
+			} else if (ego->modifiers[i]) {
+				obj->modifiers[i] = (ego->modifiers[i] > 0) ?
+					MAX(1, obj->pval) :
+					MIN(-1, -obj->pval);
+				if (flip_sign) {
+					obj->modifiers[i] *= -1;
+				}
 			}
 		}
-
-		/* Apply modifiers */
-		for (i = 0; i < OBJ_MOD_MAX; i++) {
-			obj->modifiers[i] = ego->modifiers[i] != 0 ? obj->pval : 0;
-		}
 	} else {
-		/* Remember pval for lights */
-		int light_pval = tval_is_light(obj) ? obj->pval : 0;
-
 		/* Apply extra ego bonuses */
 		if (ego->att) obj->att += randint1(ego->att);
 		if (ego->evn) obj->evn += randint1(ego->evn);
@@ -328,17 +376,69 @@ void ego_apply_magic(struct object *obj, bool smithing)
 		if (ego->pd) obj->pd += randint1(ego->pd);
 		if (ego->ps) obj->ps += randint1(ego->ps);
 
-		if (of_has(ego->flags, OF_CURSED) && ego->pval) {
-			obj->pval -= randint1(ego->pval);
-		} else if (ego->pval) {
-			obj->pval += randint1(ego->pval);
-		}
+		/*
+		 * Change any modifiers that could be non-zero in the kind
+		 * or are affected by the ego.  Note that if the kind allows
+		 * a range of values for a modifier that variation will
+		 * be suppressed by applying an ego that adjusts modifiers.
+		 * That is to mimic Sil's behavior where all non-zero modifiers
+		 * are either -pval or +pval where pval is what Sil stores in
+		 * the object's pval field.
+		 */
+		if (ego->pval > 0) {
+			bool flip_sign;
+			int pval = extract_kind_pval(obj->kind, AVERAGE,
+				&flip_sign);
 
-		/* Apply modifiers */
-		for (i = 0; i < OBJ_MOD_MAX; i++) {
-			obj->modifiers[i] = ego->modifiers[i] != 0 ? obj->pval : 0;
+			if (of_has(ego->flags, OF_CURSED)) {
+				pval -= randint1(ego->pval);
+			} else {
+				pval += randint1(ego->pval);
+			}
+
+			for (i = 0; i < OBJ_MOD_MAX; i++) {
+				int min_m = randcalc(obj->kind->modifiers[i],
+					0, MINIMISE);
+				int max_m = randcalc(obj->kind->modifiers[i],
+					z_info->dun_depth, MAXIMISE);
+
+				if (min_m == SPECIAL_VALUE) {
+					min_m = randcalc(obj->kind->special1,
+						0, MINIMISE);
+					if (!min_m && obj->kind->special2) {
+						min_m = obj->kind->special2;
+					}
+				}
+				if (max_m == SPECIAL_VALUE) {
+					max_m = randcalc(obj->kind->special1,
+						z_info->dun_depth, MAXIMISE);
+					if (!max_m && obj->kind->special2) {
+						max_m = obj->kind->special2;
+					}
+				}
+
+				if (min_m || max_m) {
+					if (min_m >= 0) {
+						obj->modifiers[i] = pval;
+					} else if (max_m > 0) {
+						obj->modifiers[i] =
+							(max_m >= -min_m) ?
+							pval : -pval;
+					} else {
+						obj->modifiers[i] = -pval;
+					}
+					if (flip_sign) {
+						obj->modifiers[i] *= -1;
+					}
+				} else if (ego->modifiers[i]) {
+					obj->modifiers[i] = (ego->modifiers[i]
+						> 0) ? pval : -pval;
+					if (flip_sign) {
+						obj->modifiers[i] *= -1;
+					}
+				}
+			}
 		}
-		obj->pval = light_pval;
 	}
 
 	/* Apply flags */
@@ -1312,6 +1412,164 @@ struct object *make_object(struct chunk *c, int lev, bool good, bool great,
 	apply_magic(new_obj, lev, true, good, great);
 
 	return new_obj;
+}
+
+
+/**
+ * Map NarSil's modifier values to Sil's pval.
+ *
+ * \param kind is the kind of object to be queried.
+ * \param rand_aspect controls whether a starting (rand_aspect == AVERAGE),
+ * minimum (rand_aspect == MINIMISE) or maximum (rand_aspect == MAXIMISE) pval
+ * is desired.  If rand_aspect is not AVERAGE, MINIMISE, or MAXIMISE, the
+ * result will be the same as if rand_aspect was equal to AVERAGE.
+ * \param flip_sign_out will, if not NULL, be dereferenced and set to true or
+ * false.  That value can be used by the caller in this fashion to determine
+ * whether to substitute -pval or pval for a modifier that can be non-zero:
+ *     if (modifier's minimum possible value != 0 || modifier's maximum
+ *             possible value != 0) {
+ *         if (modifier's minimum possible value >= 0) {
+ *             modifier's current value = pval;
+ *         } else if (modifier's maximum possible value > 0) {
+ *             if (modifier's maximum possible value >= -1 * modifier's
+ *                     minimum possible value) {
+ *                 modifier's current value = pval;
+ *             } else {
+ *                 modifier's current value = -pval;
+ *             }
+ *         } else {
+ *             modifier's current value = -pval;
+ *         }
+ *         if (*flip_sign_out) {
+ *             modifier's current value *= -1;
+ *         }
+ *     }
+ *
+ * NarSil allows different non-zero values for the modifiers.  For Sil, those
+ * enchantments are either -pval or +pval where pval is the value that Sil
+ * stores in the object's pval field.  This function looks through a kind's
+ * modifiers and extracts something appropriate to use as the value for
+ * that single value.
+ *
+ * If a kind is to be used in smithing or with specials that affect modifiers,
+ * it will work better if it has only one non-zero modifier or all the non-zero
+ * modifiers will take the same value ignoring the sign.  Some accommodations
+ * are made for modifiers with a range of values, but those will work better
+ * if there is a single such modifier or all such modifiers have the same
+ * range up to flipping the signs on the bounds of the range.
+ */
+int extract_kind_pval(const struct object_kind *kind, aspect rand_aspect,
+		bool *flip_sign_out)
+{
+	int pval_l = 0, pval_s = 0, pval_h = 0, i;
+	bool all_zero = true, all_mixed_signs = true, all_negative = true,
+		all_mixed_more_neg = true, flip_sign;
+
+	for (i = 0; i < OBJ_MOD_MAX; ++i) {
+		int min_m = randcalc(kind->modifiers[i], 0, MINIMISE);
+		int max_m = randcalc(kind->modifiers[i], z_info->dun_depth,
+			MAXIMISE);
+
+		if (min_m == SPECIAL_VALUE) {
+			min_m = randcalc(kind->special1, 0, MINIMISE);
+			if (!min_m && kind->special2) {
+				min_m = kind->special2;
+			}
+		}
+		if (max_m == SPECIAL_VALUE) {
+			max_m = randcalc(kind->special1, z_info->dun_depth,
+				MAXIMISE);
+			if (!max_m && kind->special2) {
+				max_m = kind->special2;
+			}
+		}
+		if (min_m || max_m) {
+			int this_l, this_s, this_h;
+
+			assert(max_m >= min_m);
+			if (min_m >= 0) {
+				all_negative = false;
+				all_mixed_signs = false;
+				this_l = min_m;
+				this_s = MAX(1, min_m);
+				this_h = max_m;
+			} else if (max_m > 0) {
+				all_negative = false;
+				this_s = 1;
+				/*
+				 * Flip the sign as necessary so the reported
+				 * range has a positive part at least as big
+				 * as the negative part.
+				 */
+				if (max_m >= -min_m) {
+					all_mixed_more_neg = false;
+					this_l = min_m;
+					this_h = max_m;
+				} else {
+					this_l = -max_m;
+					this_h = -min_m;
+				}
+			} else {
+				all_mixed_signs = false;
+				this_l = -max_m;
+				this_s = MAX(1, -max_m);
+				this_h = -min_m;
+			}
+			if (all_zero) {
+				all_zero = false;
+				pval_l = this_l;
+				pval_s = this_s;
+				pval_h = this_h;
+			} else {
+				if (all_mixed_signs) {
+					assert(pval_s == 1 && this_s == 1);
+					/*
+					 * If the ranges are not compatible,
+					 * use the part common to both.
+					 */
+					if (pval_h != this_h ||
+							pval_l != this_l) {
+						if (pval_h > this_h) {
+							pval_h = this_h;
+						}
+						if (pval_l < this_l) {
+							pval_l = this_l;
+						}
+					}
+				} else {
+					if (pval_h > this_h) {
+						pval_h = this_h;
+					}
+					if (pval_s > this_s) {
+						pval_s = this_s;
+					}
+					if (this_l >= 0 && pval_l > this_l) {
+						pval_l = this_l;
+					}
+				}
+			}
+		}
+	}
+
+	/*
+	 * If all the non-zero modifiers are negative or all have ranges that
+	 * span zero and those ranges all have more negative values than
+	 * positive ones, flip signs since that works better with a cursed
+	 * special:  such a special subtracts from the pval if it adjusts the
+	 * modifiers.
+	 */
+	flip_sign = !all_zero && (all_negative
+		|| (all_mixed_signs && all_mixed_more_neg));
+	if (flip_sign_out) {
+		*flip_sign_out = flip_sign;
+	}
+	if (rand_aspect == MINIMISE) {
+		return (flip_sign) ? -pval_h : pval_l;
+	}
+	if (rand_aspect == MAXIMISE) {
+		return (flip_sign) ? -pval_l : pval_h;
+	}
+	return (flip_sign) ? -pval_s : pval_s;
 }
 
 

--- a/src/obj-make.h
+++ b/src/obj-make.h
@@ -45,5 +45,7 @@ bool kind_is_good(const struct object_kind *kind);
 struct object_kind *get_obj_num(int level);
 struct object *make_object(struct chunk *c, int lev, bool good, bool great,
 		struct drop *drop);
+int extract_kind_pval(const struct object_kind *kind, aspect rand_aspect,
+		bool *flip_sign_out);
 
 #endif /* OBJECT_MAKE_H */

--- a/src/obj-properties.h
+++ b/src/obj-properties.h
@@ -181,6 +181,9 @@ struct obj_property {
 	int smith_diff;			/* difficulty for smithing */
 	int smith_cost_type;	/* cost type for smithing (XP, stats, etc) */
 	int smith_cost;			/* cost for smithing */
+	bool smith_exclude_base;	/* whether or not the property on the
+						base smithed item is excluded
+						from the difficulty and cost */
 	char *name;				/* property name */
 	char *adjective;		/* adjective for property */
 	char *neg_adj;			/* adjective for negative of property */

--- a/src/obj-smith.c
+++ b/src/obj-smith.c
@@ -337,11 +337,7 @@ int pval_valid(struct object *obj)
  */
 int pval_default(struct object *obj)
 {
-	/*
-	 * Do not want to use a light's radius as the basis for the special
-	 * value during smithing.
-	 */
-	int pval = tval_is_light(obj) ? 0 : obj->kind->pval;
+	int pval = extract_kind_pval(obj->kind, AVERAGE, NULL);
 
 	if (obj->ego && obj->ego->pval > 0) {
 		pval += object_is_cursed(obj) ? -1 : 1;
@@ -355,11 +351,7 @@ int pval_default(struct object *obj)
  */
 int pval_max(struct object *obj)
 {
-	/*
-	 * Do not want to use a light's radius as the basis for the special
-	 * value during smithing.
-	 */
-	int pval = tval_is_light(obj) ? 0 : obj->kind->pval;
+	int pval = extract_kind_pval(obj->kind, MAXIMISE, NULL);
 
 	/* Artefacts have pvals that are mostly unlimited  */
 	if (obj->artifact) {
@@ -387,11 +379,7 @@ int pval_max(struct object *obj)
  */
 int pval_min(struct object *obj)
 {
-	/*
-	 * Do not want to use a light's radius as the basis for the special
-	 * value during smithing.
-	 */
-	int pval = tval_is_light(obj) ? 0 : obj->kind->pval;
+	int pval = extract_kind_pval(obj->kind, MINIMISE, NULL);
 
 	/* Artefacts have pvals that are mostly unlimited  */
 	if (obj->artifact) {
@@ -722,7 +710,12 @@ int object_difficulty(struct object *obj, struct smithing_cost *smithing_cost)
 	int dif_mult = 100;
 	int drain = player->state.skill_use[SKILL_SMITHING] +
 		square_forge_bonus(cave, player->grid);
-    int cat = 0;
+	int cat = 0;
+	/*
+	 * Jewelry gets special treatment: namely no exclusion of base item
+	 * properties from difficulty and cost.
+	 */
+	bool jewelry = tval_is_jewelry(obj);
 
 	/* Reset smithing costs */
 	smithing_cost->stat[STAT_STR] = 0;
@@ -754,11 +747,8 @@ int object_difficulty(struct object *obj, struct smithing_cost *smithing_cost)
 		} else if (strstr(obj->kind->name, "Blasting")) {
 			smithing_cost->stat[STAT_CON] += 1;
 		}
-	} else if (!tval_is_jewelry(obj)) {
+	} else if (!jewelry) {
 		dif_inc += kind->level / 2;
-		/* We need to ignore the flags that are basic to the object type
-		 * and focus on the special/artefact ones. */
-		of_diff(flags, kind->flags);
 	}
 
 	/* Unusual weight */
@@ -806,6 +796,11 @@ int object_difficulty(struct object *obj, struct smithing_cost *smithing_cost)
 			case OBJ_PROPERTY_SKILL:
 			case OBJ_PROPERTY_MOD: {
 				diff = obj->modifiers[prop->index];
+				if (!jewelry && prop->smith_exclude_base) {
+					diff -= randcalc(
+						obj->kind->modifiers[prop->index],
+						0, AVERAGE);
+				}
 				if (diff != 0) {
 					dif_mod(diff, prop->smith_diff, &dif_inc);
 					adjust_smithing_cost(diff, prop, smithing_cost);
@@ -813,7 +808,10 @@ int object_difficulty(struct object *obj, struct smithing_cost *smithing_cost)
 				break;
 			}
 			case OBJ_PROPERTY_FLAG: {
-				if (of_has(flags, prop->index)) {
+				if (of_has(flags, prop->index)
+						&& (jewelry
+						|| !prop->smith_exclude_base
+						|| !of_has(kind->flags, prop->index))) {
 					if (prop->smith_diff > 0) {
 						dif_inc += prop->smith_diff;
 						adjust_smithing_cost(1, prop, smithing_cost);
@@ -824,20 +822,31 @@ int object_difficulty(struct object *obj, struct smithing_cost *smithing_cost)
 				break;
 			}
 			case OBJ_PROPERTY_RESIST: {
-				if (obj->el_info[prop->index].res_level == 1) {
+				if (obj->el_info[prop->index].res_level == 1
+						&& (jewelry
+						|| !prop->smith_exclude_base
+						|| kind->el_info[prop->index].res_level == 0)) {
 					dif_inc += prop->smith_diff;
 					adjust_smithing_cost(1, prop, smithing_cost);
 				}
 				break;	
 			}
 			case OBJ_PROPERTY_SLAY: {
-				if (obj->slays && (obj->slays[prop->index])) {
+				if (obj->slays && obj->slays[prop->index]
+						&& (jewelry
+						|| !prop->smith_exclude_base
+						|| !(kind->slays
+						&& kind->slays[prop->index]))) {
 					dif_inc += prop->smith_diff;
 				}
 				break;
 			}
 			case OBJ_PROPERTY_BRAND: {
-				if (obj->brands && (obj->brands[prop->index])) {
+				if (obj->brands && obj->brands[prop->index]
+						&& (jewelry
+						|| !prop->smith_exclude_base
+						|| !(kind->brands
+						&& kind->brands[prop->index]))) {
 					dif_inc += prop->smith_diff;
 					adjust_smithing_cost(1, prop, smithing_cost);
 					smith_brands++;
@@ -1359,12 +1368,56 @@ void add_object_property(struct obj_property *prop, struct object *obj,
 void remove_object_property(struct obj_property *prop, struct object *obj)
 {
 	int idx = prop ? prop->index : -1;
+	int min_m, max_m;
+
 	assert(idx >= 0);
 	switch (prop->type) {
 		case OBJ_PROPERTY_STAT:
 		case OBJ_PROPERTY_SKILL:
 		case OBJ_PROPERTY_MOD: {
-			obj->modifiers[idx] = 0;
+			/*
+			 * If the object's kind allows for a non-zero modifier,
+			 * removing the property will not prevent adjustment
+			 * of the modifier:  it will still fluctuate with the
+			 * value set for the special bonus.
+			 */
+			min_m = randcalc(obj->kind->modifiers[idx],
+				0, MINIMISE);
+			max_m = randcalc(obj->kind->modifiers[idx],
+				z_info->dun_depth, MAXIMISE);
+			if (min_m == SPECIAL_VALUE) {
+				min_m = randcalc(obj->kind->special1,
+					0, MINIMISE);
+				if (!min_m && obj->kind->special2) {
+					min_m = obj->kind->special2;
+				}
+			}
+			if (max_m == SPECIAL_VALUE) {
+				max_m = randcalc(obj->kind->special1,
+					z_info->dun_depth, MAXIMISE);
+				if (!max_m && obj->kind->special2) {
+					max_m = obj->kind->special2;
+				}
+			}
+			if (min_m || max_m) {
+				bool flip_sign;
+
+				if (min_m >= 0) {
+					obj->modifiers[idx] = 1;
+				} else if (max_m > 0) {
+					obj->modifiers[idx] =
+						(max_m >= -min_m) ? 1 : -1;
+				} else {
+					obj->modifiers[idx] = 1;
+				}
+				(void)extract_kind_pval(obj->kind, AVERAGE,
+					&flip_sign);
+				if (flip_sign) {
+					obj->modifiers[idx] *= -1;
+				}
+			} else {
+				obj->modifiers[idx] = 0;
+			}
 			break;
 		}
 		case OBJ_PROPERTY_FLAG: {

--- a/src/ui-smith.c
+++ b/src/ui-smith.c
@@ -110,15 +110,19 @@ static bool pval_included = false;
 
 static void include_pval(struct object *obj)
 {
-	int i;
 	if (!pval_included) {
 		object_wipe(smith_obj_backup);
 		object_copy(smith_obj_backup, smith_obj);
 	}
 	if (pval_valid(obj)) {
+		int i;
+
 		obj->pval = pval;
 		for (i = 0; i < OBJ_MOD_MAX; i++) {
-			if (ABS(obj->modifiers[i]) <= 1) obj->modifiers[i] = pval * ABS(obj->modifiers[i]);
+			if (obj->modifiers[i]) {
+				obj->modifiers[i] = (obj->modifiers[i] < 0) ?
+					-pval : pval;
+			}
 		}
 	}
 	pval_included = true;


### PR DESCRIPTION
In the unmodded game, the noticeable differences are for smithing artifact shovels, mattocks, or shadow cloaks, smithing ego shadow cloaks, or ego shadow cloaks from dungeoon generation or monster drops.  Resolves https://github.com/NickMcConnell/NarSil/issues/851 for the 1.3 branch.  Corrects mismatches with Sil 1.3 for smithed artifact shadow cloaks, shovels, and mattocks that https://github.com/NickMcConnell/NarSil/commit/a7caa79e71d4591b7fe739bce99c609f7282aef6 does not.

Shovels and mattocks now use the tunneling modifier for their base digging bonus rather than the DIG_1 or DIG_2 flags.