### PR TITLE
Mark ordinary weapons and armour as known in the tutorial - 1.3

### DIFF
--- a/src/tutorial.c
+++ b/src/tutorial.c
@@ -1316,6 +1316,11 @@ struct object *tutorial_create_object(const struct tutorial_item *item)
 			break;
 		}
 	}
+	/* Identify ordinary weapons/armour like apply_magic() does. */
+	if (!obj->ego && tval_has_variable_power(obj)
+			&& !tval_is_jewelry(obj)) {
+		object_know(obj);
+	}
 	return obj;
 }
 

--- a/src/ui-object.c
+++ b/src/ui-object.c
@@ -1231,6 +1231,9 @@ void display_object_kind_recall(struct object_kind *kind)
 	struct object object = OBJECT_NULL;
 	object_prep(&object, kind, 0, EXTREMIFY);
 
+	if (kind->aware || !kind->flavor) {
+		object_know(&object);
+	}
 	display_object_recall(&object);
 	object_wipe(&object);
 }


### PR DESCRIPTION
For kind recall, mark the item as known in the same circumstances as the knowledge menu does.  With https://github.com/NickMcConnell/NarSil/pull/872 also in place for the 1.3 branch, causes the tunneling bonus for shovels and mattocks to be shown in kind recall and allows the tunneling bonus for the tutorial's shovel to be seen without first wielding it.  That better emulates what Sil 1.3 does.