### PR TITLE
In the tutorial, set up known version of starting kit as normal birth does

### DIFF
--- a/src/ui-tutorial.c
+++ b/src/ui-tutorial.c
@@ -588,6 +588,7 @@ void start_tutorial(void)
 				 * be an issue if the birth process allows
 				 * artifacts in the starting kit.
 				 */
+				object_free(curr->known);
 				object_free(curr);
 				curr = next;
 			}
@@ -611,6 +612,8 @@ void start_tutorial(void)
 					continue;
 				}
 				obj->origin = ORIGIN_BIRTH;
+				obj->known = object_new();
+				object_set_base_known(player, obj);
 				object_flavor_aware(player, obj);
 				if (kit->equipped) {
 					/*
@@ -644,6 +647,7 @@ void start_tutorial(void)
 								obj->artifact,
 								false);
 						}
+						object_free(obj->known);
 						object_free(obj);
 						continue;
 					}


### PR DESCRIPTION
Also plug memory leaks for the known versions of objects if the tutorial purges the default starting kit or can not fit an item from the starting kit in the pack.  Changes have no effect on the unmodded game as the tutorial currently does not modify the default starting kit for the player.