### PR TITLE
Have acidic blows affect equipped armour as in Sil 1.3 - 1.3

### DIFF
--- a/src/mon-blows.c
+++ b/src/mon-blows.c
@@ -286,8 +286,13 @@ static void melee_effect_elemental(melee_effect_handler_context_t *context,
 	}
 
 	take_hit(context->p, context->net_dam, context->ddesc);
-	inven_damage(context->p, type, MIN((context->net_dam / 10) + 1, 3), res);
-	ident_element(context->p, type);
+	if (!context->p->is_dead) {
+		if (type == PROJ_ACID) {
+			minus_ac(context->p);
+		}
+		inven_damage(context->p, type, MIN((context->net_dam / 10) + 1, 3), res);
+		ident_element(context->p, type);
+	}
 }
 
 /**


### PR DESCRIPTION
See melee1.c:1081-1096 and spells1.c:998-1013 in Sil 1.3.  May explain Infinitum's comments about acid damage to equipment here, https://angband.live/forums/forum/angband/sil/10693-narsil-1-3-0?p=228499#post228499 .  For an elemental blow, skip identifying the element or applying object damage when the player died to the blow.