### PR TITLE
Avoid warnings on msys2 about truncation when initializing array from string - 1.3

### DIFF
--- a/src/savefile.c
+++ b/src/savefile.c
@@ -78,7 +78,7 @@ bool character_saved;
  * Magic bits at beginning of savefile
  */
 static const uint8_t savefile_magic[4] = { 83, 97, 118, 101 };
-static const uint8_t savefile_name[4] = "USIL";
+static const uint8_t savefile_name[4] = { 'U', 'S', 'I', 'L' };
 
 /* Some useful types */
 typedef int (*loader_t)(void);

--- a/src/tests/unit-test-data.h
+++ b/src/tests/unit-test-data.h
@@ -411,7 +411,7 @@ static struct monster_base TEST_DATA test_rb_info = {
 	.next = NULL,
 	.name = townsfolk_name,
 	.text = townsfolk_desc,
-	.flags = "\0\0\0\0\0\0\0\0\0\0",
+	.flags = { '\0', '\0', '\0' },
 	.d_char = 116,
 	.pain = NULL,
 	
@@ -616,8 +616,8 @@ static monster_lore TEST_DATA test_lore = {
 
 	.blows = &test_blow[0],
 
-	.flags = "\0\0\0\0\0\0\0\0\0\0",
-	.spell_flags = "\0\0\0",
+	.flags = { '\0', '\0', '\0' },
+	.spell_flags = { '\0', '\0', '\0' },
 	.drops = NULL,
 	.all_known = false,
 	.blow_known = &test_blows_known[0],

--- a/src/z-dice.c
+++ b/src/z-dice.c
@@ -129,20 +129,20 @@ static dice_state_t dice_parse_state_transition(dice_state_t state,
 												dice_input_t input)
 {
 	static unsigned char state_table[DICE_STATE_MAX][DICE_INPUT_MAX] = {
-		/* Input:								&-+dm$DU0 */
-		/*[DICE_STATE_START] = */	   /* A */ ".B.EHKB..",
-		/*[DICE_STATE_BASE_DIGIT] = */  /* B */ "..CE..B.C",
-		/*[DICE_STATE_FLUSH_BASE] = */  /* C */ "...EHKD..",
-		/*[DICE_STATE_DICE_DIGIT] = */  /* D */ "...E..D..",
-		/*[DICE_STATE_FLUSH_DICE] = */  /* E */ ".....KF..",
-		/*[DICE_STATE_SIDE_DIGIT] = */  /* F */ "G...H.F.G",
-		/*[DICE_STATE_FLUSH_SIDE] = */  /* G */ "....H....",
-		/*[DICE_STATE_BONUS] = */	   /* H */ ".....KI..",
-		/*[DICE_STATE_BONUS_DIGIT] = */ /* I */ "......I.J",
-		/*[DICE_STATE_FLUSH_BONUS] = */ /* J */ ".........",
-		/*[DICE_STATE_VAR] = */		 /* K */ ".......L.",
-		/*[DICE_STATE_VAR_CHAR] = */	/* L */ "G.CEH..LM",
-		/*[DICE_STATE_FLUSH_ALL] = */   /* M */ "........."
+		/* Input:			        { '&', '-', '+', 'd', 'm', '$', 'D', 'U', '0' */
+		/*[DICE_STATE_START] = */	/* A */ { '.', 'B', '.', 'E', 'H', 'K', 'B', '.', '.' },
+		/*[DICE_STATE_BASE_DIGIT] = */	/* B */ { '.', '.', 'C', 'E', '.', '.', 'B', '.', 'C' },
+		/*[DICE_STATE_FLUSH_BASE] = */  /* C */ { '.', '.', '.', 'E', 'H', 'K', 'D', '.', '.' },
+		/*[DICE_STATE_DICE_DIGIT] = */  /* D */ { '.', '.', '.', 'E', '.', '.', 'D', '.', '.' },
+		/*[DICE_STATE_FLUSH_DICE] = */  /* E */ { '.', '.', '.', '.', '.', 'K', 'F', '.', '.' },
+		/*[DICE_STATE_SIDE_DIGIT] = */  /* F */ { 'G', '.', '.', '.', 'H', '.', 'F', '.', 'G' },
+		/*[DICE_STATE_FLUSH_SIDE] = */  /* G */ { '.', '.', '.', '.', 'H', '.', '.', '.', '.' },
+		/*[DICE_STATE_BONUS] = */	/* H */ { '.', '.', '.', '.', '.', 'K', 'I', '.', '.' },
+		/*[DICE_STATE_BONUS_DIGIT] = */ /* I */ { '.', '.', '.', '.', '.', '.', 'I', '.', 'J' },
+		/*[DICE_STATE_FLUSH_BONUS] = */ /* J */ { '.', '.', '.', '.', '.', '.', '.', '.', '.' },
+		/*[DICE_STATE_VAR] = */		/* K */ { '.', '.', '.', '.', '.', '.', '.', 'L', '.' },
+		/*[DICE_STATE_VAR_CHAR] = */	/* L */ { 'G', '.', 'C', 'E', 'H', '.', '.', 'L', 'M' },
+		/*[DICE_STATE_FLUSH_ALL] = */	/* M */ { '.', '.', '.', '.', '.', '.', '.', '.', '.' }
 	};
 
 	if (state == DICE_STATE_MAX || input == DICE_INPUT_MAX)


### PR DESCRIPTION
The text of such warnings begins with "warning: initializer-string for array of 'unsigned char' truncates NUL terminator but destination lacks 'nonstring' a ttribute".  Those warnings are controlled by the -Wunterminated-string-initialization option.