### PR TITLE
configure: remove AC_C_CONST check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -101,7 +101,6 @@ AC_PATH_PROG(CP, cp)
 AC_HEADER_DIRENT
 AC_CHECK_HEADERS([fcntl.h])
 AC_HEADER_STDBOOL
-AC_C_CONST
 AC_CHECK_FUNCS([mkdir setresgid setegid stat])
 
 dnl needed because h-basic.h checks for this define for autoconf support.


### PR DESCRIPTION
This macro checks for the compiler not supporting const correctly. The manual for autoconf, even as far back as version 2.60 (~2007), described this as obsolescent and all existing C compilers do support const properly.