### PR TITLE
Avoid extraneous path separator in the user and archive directories

### DIFF
--- a/src/z-file.c
+++ b/src/z-file.c
@@ -156,7 +156,7 @@ static void path_process(char *buf, size_t len, size_t *cur_len,
 
 		/* Copy across */
 		strnfcat(buf, len, cur_len, "%s%s", pw->pw_dir, PATH_SEP);
-		if (s) strnfcat(buf, len, cur_len, "%s", s);
+		if (s) strnfcat(buf, len, cur_len, "%s", s + strlen(PATH_SEP));
 	} else
 
 #endif /* defined(UNIX) */


### PR DESCRIPTION
Happens when PRIVATE_USER_PATH with its default value, "~/.angband", is used.  Resolves https://github.com/angband/angband/issues/6237 .