### PR TITLE
Avoid warnings for mismatched format arguments with 32-bit compilation

### DIFF
--- a/src/ui-knowledge.c
+++ b/src/ui-knowledge.c
@@ -707,7 +707,7 @@ static void display_group_member(struct menu *menu, int oid,
 		uint8_t a = *o_funcs->xattr(oid);
 		char buf[12];
 
-		strnfmt(buf, sizeof(buf), "%d/%d", a, c);
+		strnfmt(buf, sizeof(buf), "%d/%ld", a, (long int)c);
 		c_put_str(attr, buf, row, 64 - (int) strlen(buf));
 	}
 }

--- a/src/ui-prefs.c
+++ b/src/ui-prefs.c
@@ -211,8 +211,8 @@ void dump_objects(ang_file *fff)
 		if (!kind->name || !kind->tval) continue;
 
 		object_short_name(name, sizeof name, kind->name);
-		file_putf(fff, "object:%s:%s:%d:%d\n", tval_find_name(kind->tval),
-				name, kind_x_attr[i], kind_x_char[i]);
+		file_putf(fff, "object:%s:%s:%d:%ld\n", tval_find_name(kind->tval),
+				name, kind_x_attr[i], (long int)kind_x_char[i]);
 	}
 }
 

--- a/src/wiz-spoil.c
+++ b/src/wiz-spoil.c
@@ -480,6 +480,7 @@ void spoil_mon_desc(const char *fname)
 	char health[80];
 	char prot[80];
 	char graphics[80];
+	char *mbbuf;
 
 	uint16_t *who;
 
@@ -517,11 +518,14 @@ void spoil_mon_desc(const char *fname)
 	/* Sort the array by dungeon depth of monsters */
 	sort(who, n, sizeof(*who), cmp_monsters);
 
+	mbbuf = mem_alloc(text_wcsz() + 1);
+
 	/* Scan again */
 	for (i = 0; i < n; i++) {
 		struct monster_race *race = &r_info[who[i]];
 		const char *name = race->name;
 		size_t u8len;
+		int n_mbbuf;
 
 		/* Get the "name" */
 		if (rf_has(race->flags, RF_QUESTOR))
@@ -544,8 +548,16 @@ void spoil_mon_desc(const char *fname)
 		strnfmt(prot, sizeof(prot), "%d:%dd%d", race->evn, race->pd, race->ps);
 
 		/* Hack -- use visual instead */
-		strnfmt(graphics, sizeof(graphics), "%s '%c'",
-				attr_to_text(race->d_attr), race->d_char);
+		n_mbbuf = text_wctomb(mbbuf, race->d_char);
+		if (n_mbbuf > 0) {
+			mbbuf[n_mbbuf] = '\0';
+			strnfmt(graphics, sizeof(graphics), "%s '%s'",
+				attr_to_text(race->d_attr), mbbuf);
+		} else {
+			strnfmt(graphics, sizeof(graphics),
+				"%s (invalid character)",
+				attr_to_text(race->d_attr));
+		}
 
 		/*
 		 * Dump the info.  The rationale for handling the first column
@@ -567,6 +579,8 @@ void spoil_mon_desc(const char *fname)
 
 	/* End it */
 	file_putf(fh, "\n");
+
+	mem_free(mbbuf);
 
 	/* Free the "who" array */
 	mem_free(who);
@@ -600,6 +614,7 @@ void spoil_mon_info(const char *fname)
 	uint16_t *who;
 	int count = 0;
 	textblock *tb = NULL;
+	char *mbbuf;
 
 	/* Open the file */
 	path_build(buf, sizeof(buf), ANGBAND_DIR_USER, fname);
@@ -631,11 +646,15 @@ void spoil_mon_info(const char *fname)
 
 	sort(who, count, sizeof(*who), cmp_monsters);
 
+	mbbuf = mem_alloc(text_wcsz() + 1);
+
 	/* List all monsters in order. */
 	for (n = 0; n < count; n++) {
 		int r_idx = who[n];
 		const struct monster_race *race = &r_info[r_idx];
 		const struct monster_lore *lore = &l_list[r_idx];
+		int n_mbbuf;
+
 		tb = textblock_new();
 
 		/* Line 1: prefix, name, color, and symbol */
@@ -651,7 +670,13 @@ void spoil_mon_info(const char *fname)
 		textblock_append(tb, "%s", race->name);
 		textblock_append(tb, "  (");	/* ---)--- */
 		textblock_append(tb, "%s", attr_to_text(race->d_attr));
-		textblock_append(tb, " '%c')\n", race->d_char);
+		n_mbbuf = text_wctomb(mbbuf, race->d_char);
+		if (n_mbbuf > 0) {
+			mbbuf[n_mbbuf] = '\0';
+			textblock_append(tb, " '%s')\n", mbbuf);
+		} else {
+			textblock_append(tb, " (invalid character))\n");
+		}
 
 		/* Line 2: number, level, rarity, speed, HP, AC, exp */
 		textblock_append(tb, "=== ");
@@ -675,6 +700,8 @@ void spoil_mon_info(const char *fname)
 		textblock_free(tb);
 		tb = NULL;
 	}
+
+	mem_free(mbbuf);
 
 	/* Free the "who" array */
 	mem_free(who);


### PR DESCRIPTION
Seen with gcc 12.2.0 on a 32-bit version of Debian 12.  Two (both from writing monster spoilers) came from assuming that a wchar_t could be trivially converted to a char.