### PR TITLE
Avoid warnings for mismatched format arguments with 32-bit compilation - 1.3

### DIFF
--- a/src/ui-knowledge.c
+++ b/src/ui-knowledge.c
@@ -707,7 +707,7 @@ static void display_group_member(struct menu *menu, int oid,
 		uint8_t a = *o_funcs->xattr(oid);
 		char buf[12];
 
-		strnfmt(buf, sizeof(buf), "%d/%d", a, c);
+		strnfmt(buf, sizeof(buf), "%d/%ld", a, (long int)c);
 		c_put_str(attr, buf, row, 64 - (int) strlen(buf));
 	}
 }

--- a/src/ui-prefs.c
+++ b/src/ui-prefs.c
@@ -211,8 +211,8 @@ void dump_objects(ang_file *fff)
 		if (!kind->name || !kind->tval) continue;
 
 		object_short_name(name, sizeof name, kind->name);
-		file_putf(fff, "object:%s:%s:%d:%d\n", tval_find_name(kind->tval),
-				name, kind_x_attr[i], kind_x_char[i]);
+		file_putf(fff, "object:%s:%s:%d:%ld\n", tval_find_name(kind->tval),
+				name, kind_x_attr[i], (long int)kind_x_char[i]);
 	}
 }
 


### PR DESCRIPTION
Seen with gcc 12.2.0 on a 32-bit version of Debian 12.  Two (both from writing monster spoilers) came from assuming that a wchar_t could be trivially converted to a char.