### PR TITLE
doxygen conf updates to get building. mainpage md. gitignore build dir - 1.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ docs/manual.pdf
 docs/manual.tex
 docs/manual.toc
 docs/_build
+src/doc/_doxygen/
 lib/user/CharOutput.txt
 lib/user/lore.txt
 lib/user/save/*

--- a/src/doc/doxygen-mainpage.md
+++ b/src/doc/doxygen-mainpage.md
@@ -1,0 +1,3 @@
+# This is the doxygen mainpage
+
+### TODO fill this out

--- a/src/doc/doxygen.conf
+++ b/src/doc/doxygen.conf
@@ -58,7 +58,7 @@ PROJECT_LOGO           =
 # entered, it will be relative to the location where doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = src/doc/
+OUTPUT_DIRECTORY       = src/doc/_doxygen
 
 # If the CREATE_SUBDIRS tag is set to YES, then doxygen will create 4096 sub-
 # directories (in 2 levels) under the output directory of each output format and
@@ -753,7 +753,7 @@ WARN_LOGFILE           =
 # spaces.
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  =
+INPUT                  = src src/doc/doxygen-mainpage.md
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -891,7 +891,7 @@ FILTER_SOURCE_PATTERNS =
 # (index.html). This can be useful if you have a project on for instance GitHub
 # and want to reuse the introduction page also for the doxygen output.
 
-USE_MDFILE_AS_MAINPAGE =
+USE_MDFILE_AS_MAINPAGE = src/doc/doxygen-mainpage.md
 
 #---------------------------------------------------------------------------
 # Configuration options related to source browsing
@@ -1020,7 +1020,7 @@ GENERATE_HTML          = YES
 # The default directory is: html.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_OUTPUT            = doc
+HTML_OUTPUT            = .
 
 # The HTML_FILE_EXTENSION tag can be used to specify the file extension for each
 # generated HTML page (for example: .htm, .php, .asp).
@@ -1069,7 +1069,7 @@ HTML_FOOTER            =
 # obsolete.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_STYLESHEET        = stylesheet.css
+HTML_STYLESHEET        =
 
 # The HTML_EXTRA_STYLESHEET tag can be used to specify additional user-defined
 # cascading style sheets that are included after the standard style sheets
@@ -1082,7 +1082,7 @@ HTML_STYLESHEET        = stylesheet.css
 # list). For an example see the documentation.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_EXTRA_STYLESHEET  =
+HTML_EXTRA_STYLESHEET  = stylesheet.css
 
 # The HTML_EXTRA_FILES tag can be used to specify one or more extra images or
 # other source files which should be copied to the HTML output directory. Note


### PR DESCRIPTION
Port Jordan Philyaw's changes to Vanilla to reenable doxygen.  His comments at https://github.com/angband/angband/pull/6292 apply for NarSil as well.  Namely, use "doxygen src/doc/doxygen.conf" from the top level directory to build the documentation in src/doc/_doxygen .