### PR TITLE
Resolve doxygen warnings triggered by inadvertently using multiple parameters - 1.3

### DIFF
--- a/src/player-timed.c
+++ b/src/player-timed.c
@@ -640,13 +640,13 @@ bool player_timed_grade_lt(const struct player *p, int idx, const char *match)
  * for the effect.
  * \param v is the new value for the effect.  Internally, v is coerced to lie
  * within the range of acceptable values for the effect.
- * \param notify, if true, allows for messages, updates to the user interface,
+ * \param notify allows, if true, for messages, updates to the user interface,
  * and player disturbance if setting the effect doesn't duplicate an effect
  * already present.  If false, prevents messages, updates to the user interface,
  * and player disturbance unless setting the effect increases the effect's
  * gradation or decreases the effect's gradation when the effect has messages
  * for the gradations that lapse.
- * \param can_disturb, if true, allows for setting the effect to disturb the
+ * \param can_disturb allows, if true, for setting the effect to disturb the
  * player.
  * \return whether setting the effect caused the player to be notified.
  */
@@ -850,7 +850,7 @@ bool player_saving_throw(struct player *p, struct monster *mon, int resistance)
  * \param p is the player to check.
  * \param idx is the index, greater than equal to zero and less than TMD_MAX,
  * for the effect.
- * \param lore, if true, modifies the check so it is appropriate for filling
+ * \param lore modifies, if true, the check so it is appropriate for filling
  * in details of monster recall.
  * \return whether the player can be affected by the effect.
  */
@@ -891,15 +891,15 @@ bool player_inc_check(struct player *p, int idx, bool lore)
  * \param p is the player to affect.
  * \param idx is the index, greater than equal to zero and less than TMD_MAX,
  * for the effect.
- * \param notify, if true, allows for messages, updates to the user interface,
+ * \param notify allows, if true, for messages, updates to the user interface,
  * and player disturbance if increasing the duration doesn't duplicate an effect
  * already present.  If false, prevents messages, updates to the user interface,
  * and player disturbance unless increasing the duration increases the effect's
  * gradation or decreases the effect's gradation when the effect has messages
  * for the gradations that lapse.
- * \param can_disturb, if true, allows for setting the effect to disturb the
+ * \param can_disturb allows, if true, for setting the effect to disturb the
  * player.
- * \param check, if true, allows for the player to resist the effect if
+ * \param check allows, if true, for the player to resist the effect if
  * player_inc_check(p, idx, false) is true.
  * \return whether increasing the duration caused the player to be notified.
  */
@@ -929,14 +929,14 @@ bool player_inc_timed(struct player *p, int idx, int v, bool notify,
  * \param idx is the index, greater than equal to zero and less than TMD_MAX,
  * for the effect.
  * \param v is the amount to subtract from the effect's duration.
- * \param notify, if true or v is greater than or equal to the effect's current
- * duration, allows for messages, updates to the user interface, and player
+ * \param notify allows, if true or v is greater than or equal to the effect's
+ * current duration, for messages, updates to the user interface, and player
  * disturbance.  If false and v is less than the effect's current duration,
  * prevents messages, updates to the user interface, and player disturbance
  * unless the change to the duration increases the effect's gradation or
  * decreases the effect's gradation when the effect has messages for the
  * gradations that lapse.
- * \param can_disturb, if true, allows for the change to the duration to disturb
+ * \param can_disturb allows, if true, for the change to the duration to disturb
  * the player.
  * \return whether changing the duration caused the player to be notified.
  */
@@ -961,12 +961,12 @@ bool player_dec_timed(struct player *p, int idx, int v, bool notify,
  * \param p is the player to affect.
  * \param idx is the index, greater than equal to zero and less than TMD_MAX,
  * for the effect.
- * \param notify, if true, allows for messages, updates to the user interface,
+ * \param notify allows, if true, for messages, updates to the user interface,
  * and player disturbance if clearing the effect doesn't duplicate an effect
  * already present.  If false, prevents messages, updates to the user interface,
  * and player disturbance unless clearing the effect decreases the effect's
  * gradation and the effect has messages for the gradations that lapse.
- * \param can_disturb, if true, allows for setting the effect to disturb the
+ * \param can_disturb allows, if true, for setting the effect to disturb the
  * player.
  * \return whether clearing the effect caused the player to be notified.
  */


### PR DESCRIPTION
Doxygen allows multiple parameters to share the same description: "@param name1[optional whitespace],name2... description".  Some of the comments were inadvertently triggering that by having comma as the first non-whitespace character in what was intended as the description for a single parameter.