### PR TITLE
Resolve almost all of the the remaining warnings from doxygen - 1.3

### DIFF
--- a/src/cave-square.c
+++ b/src/cave-square.c
@@ -1013,8 +1013,7 @@ void square_know_pile(struct chunk *c, struct loc grid)
 /**
  * Return how many cardinal directions around (x, y) contain doors.
  * \param c current chunk
- * \param y co-ordinates
- * \param x co-ordinates
+ * \param grid is the location in c to examine
  * \return the number of walls
  */
 int square_num_doors_adjacent(struct chunk *c, struct loc grid)
@@ -1033,8 +1032,7 @@ int square_num_doors_adjacent(struct chunk *c, struct loc grid)
 /**
  * Return how many diagonal directions around (x, y) contain walls.
  * \param c current chunk
- * \param y co-ordinates
- * \param x co-ordinates
+ * \param grid is the location in c to examine
  * \return the number of walls
  */
 int square_num_walls_diagonal(struct chunk *c, struct loc grid)

--- a/src/cmd-pickup.c
+++ b/src/cmd-pickup.c
@@ -222,8 +222,9 @@ static void player_pickup_aux(struct player *p, struct object *obj,
  * Note the lack of chance for the character to be disturbed by unmarked
  * objects.  They are truly "unknown".
  *
+ * \param p is the player picking up the item.
  * \param obj is the object to pick up.
- * \param menu is whether to present a menu to the player
+ * \param menu is whether to present a menu to the player.
  */
 void player_pickup_item(struct player *p, struct object *obj, bool menu)
 {

--- a/src/datafile.c
+++ b/src/datafile.c
@@ -155,11 +155,17 @@ int code_index_in_array(const char *code_name[], const char *code)
 
 /**
  * Gets a name and argument for a value expression of the form NAME[arg]
- * \param name_and_value is the expression
- * \param string is the random value string to return (NULL if not required)
- * \param nstring is the maximum number of bytes to write to string; not used
- * if string is NULL
- * \param num is the integer to return (NULL if not required)
+ * \param value_name points to the expression to parse; on return it will be
+ * modified to replace the opening bracket with a null character.
+ * \param string will, if not NULL, receive the contents of what appears
+ * between the brackets.
+ * \param nstring is the maximum number of bytes to write to string.  It is
+ * not used when string is NULL.
+ * \param num is dereferenced and set to the integer parsed from between the
+ * brackets.  num may be NULL.  num is not used when string is not NULL.
+ * \return true if the expression was successfully parsed.  Otherwise, return
+ * false.  Note that if string and num are NULL, the expression will never be
+ * successfully parsed.
  */
 static bool find_value_arg(char *value_name, char *string, size_t nstring,
 		int *num)

--- a/src/game-input.c
+++ b/src/game-input.c
@@ -129,6 +129,7 @@ bool get_rep_dir(int *dir, bool allow_none)
  * Get an "aiming" direction from the user.
  *
  * \param dir is a pointer to an integer representing the chosen direction
+ * \param range is the maximum range to allow for "aiming"
  * \return true if a direction was chosen, otherwise return false.
  */
 bool get_aim_dir(int *dir, int range)

--- a/src/player-birth.c
+++ b/src/player-birth.c
@@ -397,7 +397,8 @@ void wield_all(struct player *p)
  * Initialize the global player as if the full birth process happened.
  * \param nrace Is the name of the race to use.  It may be NULL to use *races.
  * \param nhouse Is the name of the house to use.  It may be NULL to use
- * *housees.
+ * *houses.
+ * \param nsex Is the name of the sex to use.  It may be NULL to use *sexes.
  * \param nplayer Is the name to use for the player.  It may be NULL.
  * \return The return value will be true if the full birth process will be
  * successful.  It will be false if the process failed.  One reason for that

--- a/src/player-timed.c
+++ b/src/player-timed.c
@@ -891,6 +891,7 @@ bool player_inc_check(struct player *p, int idx, bool lore)
  * \param p is the player to affect.
  * \param idx is the index, greater than equal to zero and less than TMD_MAX,
  * for the effect.
+ * \param v is the amount by which to increase the effect's duration.
  * \param notify allows, if true, for messages, updates to the user interface,
  * and player disturbance if increasing the duration doesn't duplicate an effect
  * already present.  If false, prevents messages, updates to the user interface,

--- a/src/player-util.c
+++ b/src/player-util.c
@@ -1280,6 +1280,7 @@ static bool player_rest_disturb = false;
 /**
  * Set the number of resting turns.
  *
+ * \param p is the player trying to rest
  * \param count is the number of turns to rest or one of the REST_ constants.
  */
 void player_resting_set_count(struct player *p, int16_t count)
@@ -1403,6 +1404,7 @@ int player_get_resting_repeat_count(struct player *p)
 /**
  * Set the number of resting turns to repeat.
  *
+ * \param p is the player trying to rest
  * \param count is the number of turns requested for rest most recently.
  */
 void player_set_resting_repeat_count(struct player *p, int16_t count)

--- a/src/ui-map.c
+++ b/src/ui-map.c
@@ -331,8 +331,8 @@ void grid_data_as_text(struct grid_data *g, int *ap, wchar_t *cp, int *tap,
 
 /**
  * Get dimensions of a small-scale map (i.e. display_map()'s result).
- * \param term Is the terminal displaying the map.
- * \param chunk Is the chunk to display.
+ * \param t Is the terminal displaying the map.
+ * \param c Is the chunk to display.
  * \param tw Is the tile width in characters.
  * \param th Is the tile height in characters.
  * \param mw *mw is set to the width of the small-scale map.

--- a/src/ui-term.c
+++ b/src/ui-term.c
@@ -625,6 +625,7 @@ void Term_queue_char(term *t, int x, int y, int a, wchar_t c, int ta,
 
 /**
  * Queue a large-sized tile.
+ * \param t Is the terminal to modify.
  * \param x Is the column for the upper left corner of the tile.
  * \param y Is the row for the upper left corner of the tile.
  * \param clipy Is the lower bound for rows that should not be modified when

--- a/src/ui-visuals.c
+++ b/src/ui-visuals.c
@@ -92,7 +92,7 @@ static struct visuals_color_cycle *visuals_color_cycle_new(const char *name,
 /**
  * Deallocate a color cycle.
  *
- * \param cycle The color cycle to deallocate.
+ * \param ccycle The color cycle to deallocate.
  */
 static void visuals_color_cycle_free(struct visuals_color_cycle *ccycle)
 {
@@ -162,7 +162,7 @@ static struct visuals_color_cycle *visuals_color_cycle_copy(struct visuals_color
 /**
  * Return the next color in the cycle for a given frame.
  *
- * \param cycle The color cycle to select a color from.
+ * \param ccycle The color cycle to select a color from.
  * \param frame An arbitrary value used to select the color step.
  * \return A color or \c BASIC_COLORS if an error occurred.
  */

--- a/src/z-color.c
+++ b/src/z-color.c
@@ -270,13 +270,13 @@ uint8_t get_color(uint8_t a, int attr, int n)
  * usually is closest to 1.7.  The converted value for each of the five
  * different "quarter" values is given below:
  *
- *  Given     Gamma 1.0       Gamma 1.5       Gamma 1.7     Hex 1.7
- *  -----       ----            ----            ----          ---
- *   0/4        0.00            0.00            0.00          #00
- *   1/4        0.25            0.27            0.28          #47
- *   2/4        0.50            0.55            0.56          #8f
- *   3/4        0.75            0.82            0.84          #d7
- *   4/4        1.00            1.00            1.00          #ff
+ *   Given  | Gamma 1.0 | Gamma 1.5 | Gamma 1.7 | Hex 1.7
+ *  :-----: | :-------: | :-------: | :-------: | :-----:
+ *    0/4   |    0.00   |    0.00   |    0.00   |   0x00
+ *    1/4   |    0.25   |    0.27   |    0.28   |   0x47
+ *    2/4   |    0.50   |    0.55   |    0.56   |   0x8f
+ *    3/4   |    0.75   |    0.82   |    0.84   |   0xd7
+ *    4/4   |    1.00   |    1.00   |    1.00   |   0xff
  */
 
 /**

--- a/src/z-dict.c
+++ b/src/z-dict.c
@@ -37,11 +37,12 @@ struct dict_impl {
 /**
  * Recurse through the dictionary depth first.
  *
+ * \param d is the dictionary to examine.
  * \param element_visitor is a pointer to a function to call for each key/value
  * pair in the dictionary.  It must take three arguments:  the dictionary,
  * a pointer to the structure holding the key/value pair, and a void*.  The
  * latter is the element_closure argument passed to dict_depth_first_recurse().
- * \param element_closure is passed as is as the second argument to
+ * \param element_closure is passed as is as the third argument to
  * element_visitor.
  */
 static void dict_depth_first_recurse(dict_type d,
@@ -128,6 +129,7 @@ void dict_destroy(dict_type d)
 /**
  * Insert a key value pair into a dictionary.
  *
+ * \param d is the dictionary to modify.
  * \param key is the key.
  * \param value is the value.  This must not be NULL.
  * \return true if the key is not already present in the dictionary and the
@@ -169,6 +171,7 @@ bool dict_insert(dict_type d, void *key, void *value)
 /**
  * Get the corresponding value in a dictionary for the given key.
  *
+ * \param d is the dictionary to examine.
  * \param key is the key to look for.
  * \return the value corresponding to key.  If key is not present, the
  * return value will be NULL.

--- a/src/z-file.c
+++ b/src/z-file.c
@@ -1093,8 +1093,10 @@ bool file_write(ang_file *f, const char *buf, size_t n)
 /**
  * Read a line of text from file 'f' into buffer 'buf' of size 'n' bytes.
  *
- * Support both \r\n and \n as line endings, but not the outdated \r that used
- * to be used on Macs.  Replace non-printables with '?', and \ts with ' '.
+ * Accepts carriage return + new line (ASCII 0xd + ASCII 0xa),
+ * new line (ASCII 0xa), or carriage return (ASCII 0xa) as line endings.
+ * Replaces any tab with one to TAB_COLUMNS spaces (i.e. the number of spaces
+ * to move the offset within the string to the next multiple of TAB_COLUMNS).
  */
 #define TAB_COLUMNS 4
 


### PR DESCRIPTION
The one that remains is about not locating an include file for an unit test case and is also present in Vanilla.