### PR TITLE
Port Vanilla's changes to reduce static analyzer warnings from gcc

### DIFF
--- a/src/obj-desc.c
+++ b/src/obj-desc.c
@@ -249,7 +249,7 @@ size_t obj_desc_name_format(char *buf, size_t max, size_t end,
 					(int) (endmark - plural), plural);
 
 			fmt = endmark;
-		} else if (*fmt == '#') {
+		} else if (*fmt == '#' && modstr) {
 			/* Add modstr, with pluralisation if relevant */
 			end = obj_desc_name_format(buf, max, end, modstr, NULL,	pluralise);
 		}

--- a/src/obj-info.c
+++ b/src/obj-info.c
@@ -836,15 +836,30 @@ textblock *object_info_ego(struct ego_item *ego)
 {
 	struct object_kind *kind = NULL;
 	struct object obj = OBJECT_NULL;
-	size_t i;
 	textblock *result;
 
-	for (i = 0; i < z_info->k_max; i++) {
-		kind = &k_info[i];
-		if (!kind->name)
-			continue;
-		if (i == ego->poss_items->kidx)
-			break;
+	if (ego->poss_items) {
+		size_t i;
+
+		for (i = 0; i < z_info->k_max; i++) {
+			kind = &k_info[i];
+			if (!kind->name)
+				continue;
+			if (i == ego->poss_items->kidx)
+				break;
+		}
+	}
+	if (!kind) {
+		result = textblock_new();
+		if (ego->poss_items) {
+			textblock_append(result, "Bug: the array of kinds of "
+				"objects no longer contains the first kind "
+				"that can have this ego.");
+		} else {
+			textblock_append(result,
+				"This ego does not appear on any items.");
+		}
+		return result;
 	}
 
 	obj.kind = kind;

--- a/src/obj-properties.c
+++ b/src/obj-properties.c
@@ -129,6 +129,17 @@ void flag_message(int flag, char *name)
 	char buf[1024] = "\0";
 
 	/* See if we have a message */
+	if (!prop) {
+		if (flag < 0 || flag >= OF_MAX) {
+			msg("Bug: invalid flag index, %d, passed to "
+				"flag_message().", flag);
+		} else {
+			msg("Bug: flag '%s' (index %d) noticed but has "
+				"no entry in object_property.txt.",
+				list_obj_flag_names[flag], flag);
+		}
+		return;
+	}
 	if (!prop->msg) return;
 
 	/* Insert */

--- a/src/obj-util.c
+++ b/src/obj-util.c
@@ -387,9 +387,11 @@ const struct artifact *lookup_artifact_name(const char *name)
  */
 struct ego_item *lookup_ego_item(const char *name, int tval, int sval)
 {
+	struct object_kind *kind = lookup_kind(tval, sval);
 	int i;
 
 	/* Look for it */
+	if (!kind) return NULL;
 	for (i = 0; i < z_info->e_max; i++) {
 		struct ego_item *ego = &e_info[i];
 		struct poss_item *poss_item = ego->poss_items;
@@ -400,7 +402,6 @@ struct ego_item *lookup_ego_item(const char *name, int tval, int sval)
 
 		/* Check tval and sval */
 		while (poss_item) {
-			struct object_kind *kind = lookup_kind(tval, sval);
 			if (kind->kidx == poss_item->kidx) {
 				return ego;
 			}

--- a/src/project.c
+++ b/src/project.c
@@ -634,7 +634,7 @@ bool project(struct source origin, int rad, struct loc finish,
 	bool player_sees_grid[256];
 
 	/* Precalculated damage values for each distance. */
-	int *dam_at_dist = malloc((z_info->max_range + 1) * sizeof(*dam_at_dist));
+	int *dam_at_dist = mem_alloc((z_info->max_range + 1) * sizeof(*dam_at_dist));
 
 	/* Flush any pending output */
 	handle_stuff(player);
@@ -1028,7 +1028,7 @@ bool project(struct source origin, int rad, struct loc finish,
 						  dam_at_dist[distance_to_grid[i]], ds, typ)) {
 				notice = true;
 				if (player->is_dead) {
-					free(dam_at_dist);
+					mem_free(dam_at_dist);
 					return notice;
 				}
 				break;
@@ -1054,7 +1054,7 @@ bool project(struct source origin, int rad, struct loc finish,
 	/* Update stuff if needed */
 	if (player->upkeep->update) update_stuff(player);
 
-	free(dam_at_dist);
+	mem_free(dam_at_dist);
 
 	/* Return "something was noticed" */
 	return (notice);

--- a/src/ui-effect.c
+++ b/src/ui-effect.c
@@ -82,8 +82,10 @@ static struct menu *effect_menu_new(struct effect *effect, int count,
 		++ms_count;
 		effect = effect_next(effect);
 	}
-	/* Set the sentinel element. */
-	ms[ms_count] = NULL;
+	if (count > 0) {
+		/* Set the sentinel element. */
+		ms[ms_count] = NULL;
+	}
 
 	menu_setpriv(m, ms_count, ms);
 


### PR DESCRIPTION
Instances that could be triggered with modified data files:

1.  Do not crash in obj_desc_name_format() if the name of an object kind or the text for a flavor includes '#'.

Mistacken code thoough not readily triggerable:

1. Dynamic allocation in project() used malloc().  Use mem_alloc() instead for consistent handling of out-of-memory conditions.
2. Tolerate failed object kind lookup in lookup_ego_item() rather than crash.
3. Tolerate a zero-sized list in effect_menu_new() rather than crash.

Not known to triggerable in the current code but change to be more robust:

1. Issue an appropriate message rather than crash if asked to display ego details for an ego that can not be applied to any objects or whose list of applicable objects is inconsistent with what is in the object kind array.
2. Issue an appropriate message rather than crash if an object flag is noticed (flag_message() is called) but the index of the flag is invalid or the flag was not configured in object_property.txt.