### PR TITLE
doxygen: exclude test cases and external include files for Windows - 1.3

### DIFF
--- a/src/doc/doxygen.conf
+++ b/src/doc/doxygen.conf
@@ -784,7 +784,7 @@ RECURSIVE              = YES
 # Note that relative paths are relative to the directory from which doxygen is
 # run.
 
-EXCLUDE                = tests/*
+EXCLUDE                =
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded
@@ -800,7 +800,9 @@ EXCLUDE_SYMLINKS       = NO
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories for example use the pattern */test/*
 
-EXCLUDE_PATTERNS       =
+EXCLUDE_PATTERNS       = \
+			*/src/tests/* \
+			*/src/win/include/* \
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names
 # (namespaces, classes, functions, etc.) that should be excluded from the


### PR DESCRIPTION
The former was the intent of 2e5285aedd5eb3aa5dc6732865b685716d03fa32 .  Resolves https://github.com/angband/angband/issues/6341 (by hiding the problem; that issue could come back if doxygen is told to process the test cases).  Reduces the erroneous references links in https://github.com/angband/angband/issues/6340 (the specific case mentioned there no longer occurs; need more auditing of doxygen's output to know if other bogus references links remain).