### PR TITLE
Rework how keymaps are handled when extracting a direction

### DIFF
--- a/src/ui-effect.c
+++ b/src/ui-effect.c
@@ -43,6 +43,7 @@ static struct menu *effect_menu_new(struct effect *effect, int count,
 	char buf[80];
 
 	m->selections = all_letters_nohjkl;
+	m->flags = MN_KEYMAP_ESC;
 
 	/* Collect a string for each effect. */
 	if (count > 0) {

--- a/src/ui-input.c
+++ b/src/ui-input.c
@@ -1492,7 +1492,7 @@ static bool textui_get_rep_dir(int *dp, bool allow_5)
 
 		if (ke.type == EVT_NONE ||
 				(ke.type == EVT_KBRD
-				&& !target_dir_allow(ke.key, allow_5))) {
+				&& !target_dir_allow(ke.key, allow_5, true))) {
 			prt("Direction or <click> (Escape to cancel)? ", 0, 0);
 			ke = inkey_ex();
 		}
@@ -1527,10 +1527,17 @@ static bool textui_get_rep_dir(int *dp, bool allow_5)
 
 				/* XXX Ideally show and move the cursor here to indicate
 				 the currently "Pending" direction. XXX */
-				this_dir = target_dir_allow(ke.key, allow_5);
+				this_dir = target_dir_allow(ke.key, allow_5,
+					true);
 
-				if (this_dir)
+				if (this_dir == ESCAPE) {
+					/* Clear the prompt */
+					prt("", 0, 0);
+
+					return (false);
+				} else if (this_dir) {
 					dir = dir_transitions[dir][this_dir];
+				}
 
 				if (player->opts.lazymove_delay == 0 || ++keypresses_handled > 1)
 					break;
@@ -1646,8 +1653,12 @@ static bool textui_get_aim_dir(int *dp, int range)
 
 					/* XXX Ideally show and move the cursor here to indicate
 					 * the currently "Pending" direction. XXX */
-					this_dir = target_dir(ke.key);
+					this_dir = target_dir_allow(ke.key,
+						false, true);
 
+					if (this_dir == ESCAPE) {
+						return false;
+					}
 					if (this_dir) {
 						dir = dir_transitions[dir][this_dir];
 					} else {

--- a/src/ui-menu.c
+++ b/src/ui-menu.c
@@ -738,9 +738,12 @@ bool menu_handle_keypress(struct menu *menu, const ui_event *in,
 		out->type = EVT_SELECT;
 	} else {
 		/* Try directional movement */
-		int dir = target_dir(in->key);
+		int dir = target_dir_allow(in->key, false,
+			menu->flags & MN_KEYMAP_ESC);
 
-		if (dir && !no_valid_row(menu, count)) {
+		if (dir == ESCAPE) {
+			out->type = EVT_ESCAPE;
+		} else if (dir && !no_valid_row(menu, count)) {
 			*out = menu->skin->process_dir(menu, dir);
 
 			if (out->type == EVT_MOVE) {

--- a/src/ui-menu.h
+++ b/src/ui-menu.h
@@ -202,7 +202,13 @@ enum
 	MN_NO_ACTION = 0x20,
 
 	/* Tags can be selected via an inscription */
-	MN_INSCRIP_TAGS = 0x40
+	MN_INSCRIP_TAGS = 0x40,
+
+	/* Allow a keymap trigger whose first character in the action is ESCAPE
+	 * to break out of the menu; note that selections, cmd_keys, and
+	 * switch_keys take precedence so a keymap trigger that is also one
+	 * of those will not break out */
+	MN_KEYMAP_ESC = 0x80
 };
 
 

--- a/src/ui-object.c
+++ b/src/ui-object.c
@@ -831,7 +831,7 @@ static struct object *item_menu(cmd_code cmd, int prompt_size, int mode)
 	menu_setpriv(m, num_obj, items);
 	m->selections = all_letters_nohjkl;
 	m->switch_keys = "/|-";
-	m->flags = (MN_PVT_TAGS | MN_INSCRIP_TAGS);
+	m->flags = (MN_PVT_TAGS | MN_INSCRIP_TAGS | MN_KEYMAP_ESC);
 
 	/* Get inscriptions */
 	m->inscriptions = mem_zalloc(10 * sizeof(char));

--- a/src/ui-target.c
+++ b/src/ui-target.c
@@ -70,10 +70,29 @@ typedef bool (*target_aux_handler)(struct chunk *c, struct player *p,
  */
 int target_dir(struct keypress ch)
 {
-	return target_dir_allow(ch, false);
+	return target_dir_allow(ch, false, false);
 }
 
-int target_dir_allow(struct keypress ch, bool allow_5)
+/**
+ * Extract, with finer control, a direction (or zero) from a character.
+ *
+ * \param ch is the keypress to examine.
+ * \param allow_5 will, if true, allow 5 to be returned as a direction.
+ * If false, zero will be returned when 5 is extracted.
+ * \param allow_esc will, if true, test if ch is the trigger for a keymap
+ * whose first character in the action is ESCAPE and, when that happens,
+ * return ESCAPE.
+ * \return an integer that is either in 0 to 4, inclusive, or 6 to 9, inclusive,
+ * indicating the direction extracted.  If it was not possible to extract a
+ * direction, return 0.  If allow_5 is true, the returned value can be 5 as
+ * well when the extracted direction is 5.  If allow_esc is true, the retured
+ * value can be ESCAPE as well if ch is the trigger for a keymap whose first
+ * character in the action is ESCAPE.
+ *
+ * When examining a keymap, should any '(' or ')' be skipped over since they
+ * do nothing but toggle how more prompts are handled?
+ */
+int target_dir_allow(struct keypress ch, bool allow_5, bool allow_esc)
 {
 	int d = 0;
 
@@ -100,13 +119,37 @@ int target_dir_allow(struct keypress ch, bool allow_5)
 			mode |= KEYMAP_MODE_ROGUE;
 		}
 
-		/* XXX see if this key has a digit in the keymap we can use */
 		act = keymap_find(mode, ch);
-		if (act) {
-			const struct keypress *cur;
-			for (cur = act; cur->type == EVT_KBRD; cur++) {
-				if (isdigit((unsigned char) cur->code))
-					d = D2I(cur->code);
+		if (act && act->type == EVT_KBRD) {
+			if (allow_esc && act->code == ESCAPE) {
+				/*
+				 * Let the player break out of the targeting
+				 * with a keymap whose action starts with
+				 * escape.  Suggested by
+				 * https://github.com/angband/angband/issues/6297 .
+				 * To save extra keystrokes by the player, it
+				 * is tempting, if there isn't a kaymap active
+				 * or the current keymap is at its end, to
+				 * insert the keymap triggered by ch into the
+				 * command queue, but we do not know if the
+				 * ESCAPE passed out here will end the
+				 * processing of the last command.
+				 */
+				d = ESCAPE;
+			} else if (((unsigned char)act->code
+					== cmd_lookup_key(CMD_WALK, mode)
+					|| (unsigned char)act->code
+					== cmd_lookup_key(CMD_RUN, mode))) {
+				/*
+				 * Let the player use a single action movement
+				 * keymap to specify the direction.
+				 */
+				++act;
+				if (act->type == EVT_KBRD
+						&& isdigit((unsigned char)act->code)
+						&& (act + 1)->type == EVT_NONE) {
+					d = D2I(act->code);
+				}
 			}
 		}
 	}
@@ -196,7 +239,7 @@ void target_display_help(bool monster, bool object, bool free)
 
 
 /**
- * Return whether a key triggers a running action.
+ * Return whether a key triggers a keymap whose only action is to run.
  */
 static bool is_running_keymap(struct keypress ch)
 {
@@ -208,14 +251,13 @@ static bool is_running_keymap(struct keypress ch)
 		mode |= KEYMAP_MODE_ROGUE;
 	}
 
-	if (act) {
-		unsigned char run_key = cmd_lookup_key(CMD_RUN, mode);
-		const struct keypress *cur;
-
-		for (cur = act; cur->type == EVT_KBRD; cur++) {
-			if ((unsigned char)cur->code == run_key) {
-				return true;
-			}
+	if (act && act->type == EVT_KBRD && (unsigned char)act->code
+			== cmd_lookup_key(CMD_RUN, mode)) {
+		++act;
+		if (act->type == EVT_NONE || (act->type == EVT_KBRD
+				&& isdigit((unsigned char)act->code)
+				&& (act + 1)->type == EVT_NONE)) {
+			return true;
 		}
 	}
 	return false;
@@ -1424,10 +1466,12 @@ bool target_set_interactive(int mode, struct loc grid, int range)
 
 		} else {
 			/* Try to extract a direction from the key press */
-			int dir = target_dir(press.key);
+			int dir = target_dir_allow(press.key, false, true);
 
 			if (!dir) {
 				bell();
+			} else if (dir == ESCAPE) {
+				done = true;
 			} else if (use_interesting_mode) {
 				/* Interesting mode direction: Pick new interesting grid */
 				int old_y = targets->pts[target_index].y;

--- a/src/ui-target.h
+++ b/src/ui-target.h
@@ -52,7 +52,7 @@
 #define TARGET_OUT_VAL_SIZE 256
 
 int target_dir(struct keypress ch);
-int target_dir_allow(struct keypress ch, bool allow_5);
+int target_dir_allow(struct keypress ch, bool allow_5, bool allow_esc);
 void target_display_help(bool monster, bool object, bool free);
 void textui_target(void);
 void textui_target_closest(void);


### PR DESCRIPTION
Only recognize a keymap trigger if its action is one walk or run command.  Also, depending on the context, allow a keymap trigger whose first key in the action is ESCAPE to break out of the selection process.  The latter resolves https://github.com/angband/angband/issues/6297 .  Such a keymap trigger can also break out of item or effect selection.  They do not affect retrieving the input when the player is prompted for a string, quantity, confirmation, or single character.  Menus used in the knowledge or preferences menu are not affected unless they use the item/effect input methods.