### PR TITLE
Skip processing keymap's remainder if command lookup/prereq/confirmation fails

### DIFF
--- a/src/ui-game.c
+++ b/src/ui-game.c
@@ -580,15 +580,35 @@ void textui_process_command(void)
 		if (cmd && cmd->prereq && !cmd->prereq()) cmd = NULL;
 
 		/* Split on type of command */
-		if (cmd && cmd->hook)
+		if (cmd && cmd->hook) {
 			/* UI command */
 			cmd->hook();
-		else if (cmd && cmd->cmd)
+		} else if (cmd && cmd->cmd) {
 			/* Game command */
 			cmdq_push_repeat(cmd->cmd, count);
-	} else
+		} else if (!cmd && inkey_next) {
+			/*
+			 * If processing a keymap, skip the rest if a command
+			 * lookup, confirmation, or prereq failed.  For
+			 * keymaps that specify multiple commands, the player
+			 * might want to continue with the keymap, but that
+			 * would require skipping over the keys in the keymap
+			 * that provide input to the command that failed.
+			 */
+			inkey_next = NULL;
+		}
+	} else {
 		/* Error */
 		do_cmd_unknown();
+		if (inkey_next) {
+			/*
+			 * As above, abandon the rest of a keymap when a
+			 * command was expected and what we got was not
+			 * recognized.
+			 */
+			inkey_next = NULL;
+		}
+	}
 }
 
 errr textui_get_cmd(cmd_context context)


### PR DESCRIPTION
Resolves https://github.com/angband/angband/issues/6289 .