### PR TITLE
Adjust some code flagged by gcc's static analysis option, -fanalyzer

### DIFF
--- a/src/obj-properties.c
+++ b/src/obj-properties.c
@@ -163,6 +163,17 @@ bool flag_slay_message(int flag, char *name, char *message, int len)
 	char buf[1024] = "\0";
 
 	/* See if we have a message */
+	if (!prop) {
+		if (flag < 0 || flag >= OF_MAX) {
+			msg("Bug: invalid flag index, %d, passed to "
+				"flag_slay_message().", flag);
+		} else {
+			msg("Bug: flag '%s' (index %d) noticed but has "
+				"no entry in object_property.txt.",
+				list_obj_flag_names[flag], flag);
+		}
+		return false;
+	}
 	if (!prop->slay_msg) return false;
 
 	/* Insert */
@@ -187,6 +198,18 @@ void element_message(int elem, char *name, bool vuln)
 	if (vuln) prop = lookup_obj_property(OBJ_PROPERTY_VULN, elem);
 
 	/* See if we have a message */
+	if (!prop) {
+		if (elem < 0 || elem >= ELEM_MAX) {
+			msg("Bug: invalid element index, %d, passed to "
+				"element_message().", elem);
+		} else {
+			msg("Bug: %s to '%s' (index %d) noticed but has no "
+				"entry in object_property.txt.",
+				(vuln) ? "vulnerability" : "resistance",
+				list_element_names[elem], elem);
+		}
+		return;
+	}
 	if (!prop->msg) return;
 
 	/* Insert */

--- a/src/ui-tutorial.c
+++ b/src/ui-tutorial.c
@@ -214,9 +214,10 @@ void start_tutorial(void)
 		if (a->v.archetype.race_name) {
 			if (streq(a->v.archetype.race_name, "*")) {
 				/* Choose one at random. */
-				const struct player_race *rc = races;
-				int nr = 0;
+				const struct player_race *rc = races->next;
+				int nr = 1;
 
+				rpick = races;
 				while (rc) {
 					++nr;
 					if (one_in_(nr)) {
@@ -315,9 +316,10 @@ void start_tutorial(void)
 
 			if (streq(a->v.archetype.sex_name, "*")) {
 				/* Choose one at random. */
-				const struct player_sex *sc = sexes;
-				int ns = 0;
+				const struct player_sex *sc = sexes->next;
+				int ns = 1;
 
+				spick = sexes;
 				while (sc) {
 					++ns;
 					if (one_in_(ns)) {


### PR DESCRIPTION
Instances that are not known to be triggerable in the current code but were chaged to be more robust:

1. Issue an appropriate message rather than crash if flag_slay_message() is called with an invalid flag or the flag was not configure in object_property.txt.
2. Issue an appropriate message rather than crash if element_message() is called with an invalid element or the resistance/vulnerability to that element was not configured in object_property.txt.

Also unroll one iteration for random selections in ui-tutorial.c to avoid some false positives from the static analysis.