### PR TITLE
Correct transfer of charges for a partial merger of stacks

### DIFF
--- a/src/obj-pile.c
+++ b/src/obj-pile.c
@@ -546,7 +546,8 @@ void object_origin_combine(struct object *obj1, const struct object *obj2)
  *
 * These assumptions are enforced by the "object_mergeable()" code.
  */
-static void object_absorb_merge(struct object *obj1, const struct object *obj2)
+static void object_absorb_merge(struct object *obj1, const struct object *obj2,
+		bool combine_charges)
 {
 	int total;
 
@@ -557,10 +558,12 @@ static void object_absorb_merge(struct object *obj1, const struct object *obj2)
 	if (obj2->note)
 		obj1->note = obj2->note;
 
-	/* Combine pvals for staves */
-	if (tval_can_have_charges(obj1)) {
-		total = obj1->pval + obj2->pval;
-		obj1->pval = total >= MAX_PVAL ? MAX_PVAL : total;
+	if (combine_charges) {
+		/* Combine pvals for staves */
+		if (tval_can_have_charges(obj1)) {
+			total = obj1->pval + obj2->pval;
+			obj1->pval = total >= MAX_PVAL ? MAX_PVAL : total;
+		}
 	}
 
 	/* Combine origin data as best we can */
@@ -584,10 +587,11 @@ void object_absorb_partial(struct object *obj1, struct object *obj2)
 	newsz1 = largest + difference;
 	newsz2 = smallest - difference;
 
+	distribute_charges(obj2, obj1, obj2->number - newsz2, false);
 	obj1->number = newsz1;
 	obj2->number = newsz2;
 
-	object_absorb_merge(obj1, obj2);
+	object_absorb_merge(obj1, obj2, false);
 }
 
 /**
@@ -601,7 +605,7 @@ void object_absorb(struct object *obj1, struct object *obj2)
 	/* Add together the item counts */
 	obj1->number = MIN(total, obj1->kind->base->max_stack);
 
-	object_absorb_merge(obj1, obj2);
+	object_absorb_merge(obj1, obj2, true);
 	if (known) {
 		if (!loc_is_zero(known->grid)) {
 			square_excise_object(player->cave, known->grid, known);
@@ -705,9 +709,9 @@ struct object *object_split(struct object *src, int amt)
 	assert(src->number > amt);
 
 	/* Distribute charges of wands, staves, or rods */
-	distribute_charges(src, dest, amt);
+	distribute_charges(src, dest, amt, true);
 	if (src->known)
-		distribute_charges(src->known, dest->known, amt);
+		distribute_charges(src->known, dest->known, amt, true);
 
 	/* Modify quantity */
 	dest->number = amt;

--- a/src/obj-util.c
+++ b/src/obj-util.c
@@ -744,8 +744,11 @@ bool obj_allows_vertical_aim(const struct object *obj)
  * \param source is the source item
  * \param dest is the target item, must be of the same type as source
  * \param amt is the number of items that are transfered
+ * \param dest_new will, if true, ignore whatever charges dest has (i.e.
+ * treat it as a new stack).
  */
-void distribute_charges(struct object *source, struct object *dest, int amt)
+void distribute_charges(struct object *source, struct object *dest, int amt,
+		bool dest_new)
 {
 	/*
 	 * Hack -- If rods, staves, or wands are dropped, the total maximum
@@ -754,10 +757,16 @@ void distribute_charges(struct object *source, struct object *dest, int amt)
 	 * to leave the original stack's pval alone. -LM-
 	 */
 	if (tval_can_have_charges(source)) {
-		dest->pval = source->pval * amt / source->number;
+		int change = source->pval * amt / source->number;
 
-		if (amt < source->number)
-			source->pval -= dest->pval;
+		if (dest_new) {
+			dest->pval = change;
+		} else {
+			dest->pval += change;
+		}
+		if (amt < source->number) {
+			source->pval -= change;
+		}
 	}
 }
 

--- a/src/obj-util.h
+++ b/src/obj-util.h
@@ -63,7 +63,8 @@ struct effect *object_effect(const struct object *obj);
 bool obj_needs_aim(const struct object *obj);
 bool obj_allows_vertical_aim(const struct object *obj);
 
-void distribute_charges(struct object *source, struct object *dest, int amt);
+void distribute_charges(struct object *source, struct object *dest, int amt,
+		bool dest_new);
 void uncurse_object(struct object *obj);
 bool verify_object(const char *prompt, const struct object *obj,
 		const struct player *p);


### PR DESCRIPTION
Ported from Vanilla's e0af0e158060a06aa8552bf76a8885be914d3e39 which resolves https://github.com/angband/angband/issues/6355 .