### PR TITLE
Correct transfer of charges for a partial merger of stacks - 1.3

### DIFF
--- a/src/obj-util.c
+++ b/src/obj-util.c
@@ -754,8 +754,11 @@ bool obj_allows_vertical_aim(const struct object *obj)
  * \param source is the source item
  * \param dest is the target item, must be of the same type as source
  * \param amt is the number of items that are transfered
+ * \param dest_new will, if true, ignore whatever charges dest has (i.e.
+ * treat it as a new stack).
  */
-void distribute_charges(struct object *source, struct object *dest, int amt)
+void distribute_charges(struct object *source, struct object *dest, int amt,
+		bool dest_new)
 {
 	/*
 	 * Hack -- If rods, staves, or wands are dropped, the total maximum
@@ -764,10 +767,16 @@ void distribute_charges(struct object *source, struct object *dest, int amt)
 	 * to leave the original stack's pval alone. -LM-
 	 */
 	if (tval_can_have_charges(source)) {
-		dest->pval = source->pval * amt / source->number;
+		int change = source->pval * amt / source->number;
 
-		if (amt < source->number)
-			source->pval -= dest->pval;
+		if (dest_new) {
+			dest->pval = change;
+		} else {
+			dest->pval += change;
+		}
+		if (amt < source->number) {
+			source->pval -= change;
+		}
 	}
 }
 

--- a/src/obj-util.h
+++ b/src/obj-util.h
@@ -63,7 +63,8 @@ struct effect *object_effect(const struct object *obj);
 bool obj_needs_aim(const struct object *obj);
 bool obj_allows_vertical_aim(const struct object *obj);
 
-void distribute_charges(struct object *source, struct object *dest, int amt);
+void distribute_charges(struct object *source, struct object *dest, int amt,
+		bool dest_new);
 void uncurse_object(struct object *obj);
 bool verify_object(const char *prompt, const struct object *obj,
 		const struct player *p);


### PR DESCRIPTION
Ported from Vanilla's e0af0e158060a06aa8552bf76a8885be914d3e39 which resolves https://github.com/angband/angband/issues/6355 .