### PR TITLE
In Rand_simple(), only use the 32 least significant bits from time()

### DIFF
--- a/src/z-rand.c
+++ b/src/z-rand.c
@@ -511,8 +511,8 @@ void rand_fix(uint32_t val)
  */
 uint32_t Rand_simple(uint32_t m)
 {
-	static time_t seed;
-	time_t v = time(NULL);
+	static uint32_t seed;
+	uint32_t v = (uint32_t)time(NULL);
 
 #ifdef UNIX
 	seed = LCRNG(seed % m) + ((v << 16) ^ v ^ getpid());


### PR DESCRIPTION
Resolves https://github.com/angband/angband/issues/6394 .