### PR TITLE
Remove set but never tested member of struct player_upkeep - 1.3

### DIFF
--- a/src/cmd-cave.c
+++ b/src/cmd-cave.c
@@ -1866,8 +1866,6 @@ void move_player(int dir, bool disarm)
 			}
 		}
 	}
-
-	player->upkeep->running_firststep = false;
 }
 
 /**

--- a/src/player-path.c
+++ b/src/player-path.c
@@ -498,9 +498,6 @@ static void run_init(int dir)
 	bool deepleft, deepright;
 	bool shortleft, shortright;
 
-	/* Mark that we're starting a run */
-	player->upkeep->running_firststep = true;
-
 	/* Save the direction */
 	run_cur_dir = dir;
 

--- a/src/player.h
+++ b/src/player.h
@@ -436,7 +436,6 @@ struct player_upkeep {
 	int resting;			/* Resting counter */
 	int running;				/* Running counter */
 	bool running_withpathfind;	/* Are we using the pathfinder ? */
-	bool running_firststep;		/* Is this our first step running? */
 
 	struct object **inven;	/* Inventory objects */
 	int total_weight;		/* Total weight being carried */

--- a/src/tests/unit-test-data.h
+++ b/src/tests/unit-test-data.h
@@ -685,7 +685,6 @@ static struct player_upkeep TEST_DATA test_player_upkeep = {
 
 	.running = 0,
 	.running_withpathfind = 0,
-	.running_firststep = 0,
 
 	.inven = NULL,
 


### PR DESCRIPTION
In Vanilla, running_firststep is only used to prevent disturbing a run or pathfinding when the first step leaves a region where traps have been detected.  That is not relevant for NarSil.