### PR TITLE
Drop trap_parser prototype from trap.h: it is already in init.h - 1.3

### DIFF
--- a/src/trap.h
+++ b/src/trap.h
@@ -95,8 +95,6 @@ struct trap
 	bitflag flags[TRF_SIZE];	/**< Trap flags (only this particular trap) */
 };
 
-extern struct file_parser trap_parser;
-
 struct trap_kind *lookup_trap(const char *desc);
 bool square_trap_specific(struct chunk *c, struct loc grid, int t_idx);
 bool square_trap_flag(struct chunk *c, struct loc grid, int flag);


### PR DESCRIPTION
Avoids redundant declaration warnings seen when building with Makefile.std on GitHub's ubuntu-latest runner (Ubuntu 24.04.3 LTS).