### PR TITLE
Remove references to lib/user/info in the packaging script for Windows - 1.3

### DIFF
--- a/scripts/pkg_win
+++ b/scripts/pkg_win
@@ -55,13 +55,11 @@ mkdir lib/icons
 mkdir lib/user
 mkdir lib/user/save
 mkdir lib/user/scores
-mkdir lib/user/info
 mkdir lib/user/archive
 mkdir lib/user/panic
 
 touch lib/user/delete.me lib/user/save/delete.me lib/user/scores/delete.me \
-      lib/user/info/delete.me lib/user/archive/delete.me \
-	  lib/user/panic/delete.me
+      lib/user/archive/delete.me lib/user/panic/delete.me
 
 cp ../*.exe .
 cp ../*.dll .
@@ -122,11 +120,6 @@ cp ../lib/tiles/old/*.png lib/tiles/old
 cp ../lib/tiles/shockbolt/*.png lib/tiles/shockbolt
 
 cp ../lib/sounds/*.mp3 lib/sounds
-
-for f in `find ../lib/user/info \( -name '*.txt' -o -name '*.hlp' \) \
-		-print` ; do
-	cp_unix2dos "$f" `echo "$f" | sed -E -e 's%^\.\./%%'`
-done
 
 cd ..
 zip -9 -r $OUT $DIR


### PR DESCRIPTION
lib/user/info was excised elsewhere some time ago in 1cdd5f536d4bd7b61e2fbfddb98755f34507d500 .