### PR TITLE
gcu: allow compiling with mouse and resizing support for PDCurses

### DIFF
--- a/src/main-gcu.c
+++ b/src/main-gcu.c
@@ -592,7 +592,7 @@ static void Term_init_gcu(term *t) {
 	/* Count init's, handle first */
 	if (active++ != 0) return;
 
-	#if defined(USE_NCURSES) && defined(KEY_MOUSE)
+	#if defined(NCURSES_MOUSE_VERSION) && defined(KEY_MOUSE)
 	/* Turn on the mouse. */
 	mousemask(ALL_MOUSE_EVENTS, NULL);
 	#endif
@@ -823,8 +823,12 @@ static errr Term_xtra_gcu_event(int v) {
 		if (i == EOF) return (1);
 	}
 
-	/* Not sure if this is portable to non-ncurses platforms */
-	#ifdef USE_NCURSES
+	/*
+	 * Both NCurses and PDCurses define KEY_RESIZE.  According to
+	 * PDCurses User's Guide, KEY_RESIZE is not part of the X/Open
+	 * specification so this generally will not work with Curses.
+	 */
+	#ifdef KEY_RESIZE
 	if (i == KEY_RESIZE) {
 		/* wait until we go one second (10 deci-seconds) before actually
 		 * doing the resizing. users often end up triggering multiple
@@ -839,7 +843,7 @@ static errr Term_xtra_gcu_event(int v) {
 	}
 	#endif
 
-	#if defined(USE_NCURSES) && defined(KEY_MOUSE)
+	#if defined(NCURSES_MOUSE_VERSION) && defined(KEY_MOUSE)
 	if (i == KEY_MOUSE) {
 		MEVENT m;
 		if (getmouse(&m) != OK) return (0);


### PR DESCRIPTION
Because main-gcu.c uses the interface from NCurses for handling mouse events, the preprocessor macro, PDC_NCMOUSE, will have to be set when compiling main-gcu.c with PDCurses in order to have mouse support.  Further work may be necessary to actually have functioning mouse events and resizing as testing with PDCurses built on top of SDL2 running in a Debian 12 virtual machine hosted by Parallels on a Mac laptop (no mouse, only a trackpad) indicated these problems:  the game received separate button press and release events but they were not close enough in time for PDCurses to send a click event which is what main-gcu.c expects and making the window bigger did not trigger the game to fill in the extra space.