### PR TITLE
workflows: replace softprops/action-gh-release with gh CLI - 1.3

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -375,6 +375,11 @@ jobs:
     name: Create GitHub Release
     runs-on: ubuntu-latest
     steps:
+      - name: Clone Project
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
       - name: Download Artifact with Configuration Information
         uses: actions/download-artifact@v8
         with:
@@ -438,16 +443,15 @@ jobs:
         with:
           name: ${{ env.MAC_ARCHIVE_ARTIFACT }}
 
+      # Use the gh CLI,  https://cli.github.com/manual/gh_release_create , to
+      # create the release.  Requires a checked out repository, thus the
+      # checkout step prior to retrieving the artifacts.
       - name: Populate Release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ steps.store_config.outputs.version }}
-          name: ${{ steps.store_config.outputs.version }}
-          target_commitish: ${{ github.sha }}
-          draft: ${{ steps.store_config.outputs.draft }}
-          prerelease: ${{ steps.store_config.outputs.prerelease }}
-          files: |
-            ${{ steps.store_src.outputs.archive_path }}
-            ${{ steps.store_win.outputs.archive_path }}
-            ${{ steps.store_mac.outputs.archive_path }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          release_tag="${{ steps.store_config.outputs.version }}"
+          options="-t $release_tag"
+          test x"${{ steps.store_config.outputs.draft }}" = xtrue && options="$options -d"
+          test x"${{ steps.store_config.outputs.prerelease }}" = xtrue && options="$options -p"
+          gh release create $release_tag ${{ steps.store_src.outputs.archive_path }} ${{ steps.store_win.outputs.archive_path }} ${{ steps.store_mac.outputs.archive_path }} $options


### PR DESCRIPTION
Resolves the last remaining issue with the transition to Node.js 24.