### PR TITLE
Make RNG's z0, z1, and z2 private

### DIFF
--- a/src/load.c
+++ b/src/load.c
@@ -376,10 +376,10 @@ int rd_randomizer(void)
 	/* for safety, make sure state_i < RAND_DEG */
 	state_i = state_i % RAND_DEG;
     
-	/* RNG variables */
-	rd_u32b(&z0);
-	rd_u32b(&z1);
-	rd_u32b(&z2);
+	/* NULL padding for compatibility with previous versions */
+	rd_u32b(&noop);
+	rd_u32b(&noop);
+	rd_u32b(&noop);
     
 	/* RNG state */
 	for (i = 0; i < RAND_DEG; i++)

--- a/src/save.c
+++ b/src/save.c
@@ -306,10 +306,10 @@ void wr_randomizer(void)
 	/* state index */
 	wr_u32b(state_i);
 
-	/* RNG variables */
-	wr_u32b(z0);
-	wr_u32b(z1);
-	wr_u32b(z2);
+	/* NULL padding for backwards compatibility with previous versions */
+	wr_u32b(0);
+	wr_u32b(0);
+	wr_u32b(0);
 
 	/* RNG state */
 	for (i = 0; i < RAND_DEG; i++)

--- a/src/z-rand.c
+++ b/src/z-rand.c
@@ -58,7 +58,6 @@ uint32_t STATE[RAND_DEG] = {0, 0, 0, 0, 0, 0, 0, 0,
 						0, 0, 0, 0, 0, 0, 0, 0,
 						0, 0, 0, 0, 0, 0, 0, 0,
 						0, 0, 0, 0, 0, 0, 0, 0};
-uint32_t z0, z1, z2;
 
 #define V0    STATE[state_i]
 #define VM1   STATE[(state_i + M1) & 0x0000001fU]
@@ -69,9 +68,10 @@ uint32_t z0, z1, z2;
 #define newV1 STATE[state_i]
 
 static uint32_t WELLRNG1024a (void){
-	z0      = VRm1;
-	z1      = Identity(V0) ^ MAT0POS (8, VM1);
-	z2      = MAT0NEG (-19, VM2) ^ MAT0NEG(-14,VM3);
+	uint32_t z0 = VRm1;
+	uint32_t z1 = Identity(V0) ^ MAT0POS (8, VM1);
+	uint32_t z2 = MAT0NEG (-19, VM2) ^ MAT0NEG(-14,VM3);
+
 	newV1   = z1 ^ z2; 
 	newV0   = MAT0NEG (-11,z0) ^ MAT0NEG(-7,z1) ^ MAT0NEG(-13,z2);
 	state_i = (state_i + 31) & 0x0000001fU;

--- a/src/z-rand.h
+++ b/src/z-rand.h
@@ -117,9 +117,6 @@ extern uint32_t Rand_value;
  */
 extern uint32_t state_i;
 extern uint32_t STATE[RAND_DEG];
-extern uint32_t z0;
-extern uint32_t z1;
-extern uint32_t z2;
 
 
 /**


### PR DESCRIPTION
They are reset, using only STATE and state_i, at each random number draw.  They do not need static storage or persistence in the save file.