### PR TITLE
Include the Windows DLLs in source archives; exclude .readthedocs.yaml - 1.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,12 @@ dist:
 	scripts/version.sh > $(TAG)/version
 	$(TAG)/autogen.sh
 	rm -rf $(TAG)/autogen.sh $(TAG)/autom4te.cache
-	tar --exclude .gitignore --exclude *.dll --exclude .github \
-		--exclude .travis.yml -czvf $(OUT) $(TAG)
+	tar \
+		--exclude .github \
+		--exclude .gitignore \
+		--exclude .readthedocs.yaml \
+		--exclude .travis.yml \
+		-czvf $(OUT) $(TAG)
 	rm -rf $(TAG)
 
 # If this isn't a --with-no-install build, build and install the documentation

--- a/scripts/pkg_src
+++ b/scripts/pkg_src
@@ -36,5 +36,10 @@ git checkout-index --prefix=$TAG/ -a &&
 	./autogen.sh &&
 	rm -rf autogen.sh autom4te.cache &&
 	cd .. &&
-	tar --exclude .gitignore --exclude *.dll -czvf $OUT $TAG &&
+	tar \
+		--exclude .github \
+		--exclude .gitignore \
+		--exclude .readthedocs.yaml \
+		--exclude .travis.yml \
+		-czvf $OUT $TAG &&
 	rm -rf $TAG


### PR DESCRIPTION
In scripts/pkg_src, exclude the files for integrating with Travis CI or GitHub that are excluded in the other pathways to building a source archive.