### PR TITLE
Unit tests: correct some expected strings for the house-info test

### DIFF
--- a/src/tests/parse/house-info.c
+++ b/src/tests/parse/house-info.c
@@ -257,7 +257,7 @@ static int test_desc0(void *state) {
 	h = (struct player_house*) parser_priv(p);
 	notnull(h);
 	notnull(h->desc);
-	require(streq(h->desc, "Fingolfin led his house into Beleriand"
+	require(streq(h->desc, "Fingolfin led his house into Beleriand "
 		"to protect its peoples from the shadow of Morgoth."));
 	ok;
 }
@@ -295,11 +295,12 @@ static int test_complete0(void *state) {
 	notnull(h->short_name);
 	require(streq(h->short_name, "Falathrim"));
 	notnull(h->desc);
-	require(streq(h->desc, "When Thingol met with Meial under the wheeling "
-		"stars, many of his folk despaired of finding him again and "
-		"journeyed to the shore, the Falas, to set sail to Valinor. "
-		"Some tarried there and dwelt in the havens on the edge of "
-		"Middle-Earth with their lord, Cirdan, the shipbuilder."));
+	require(streq(h->desc, "When Thingol met with Melian under the "
+		"wheeling stars, many of his folk despaired of finding him "
+		"again and journeyed to the shore, the Falas, to set sail to "
+		"Valinor. Some tarried there and dwelt in the havens on the "
+		"edge of Middle-Earth with their lord, Cirdan, the "
+		"shipbuilder."));
 	for (i = 0; i < STAT_MAX; ++i) {
 		eq(h->stat_adj[i], (i == STAT_DEX) ? 1 : 0);
 	}


### PR DESCRIPTION
Those should have been generating test failures.  Its unclear at the moment why they did not.