### PR TITLE
tests: use CMD_USE rather than CMD_TUNNEL with cmd_lookup() - 1.3

### DIFF
--- a/src/tests/command/lookup.c
+++ b/src/tests/command/lookup.c
@@ -31,7 +31,7 @@ static int test_cmd_lookup_orig(void *state) {
 	require(cmd_lookup('Z', KEYMAP_MODE_ORIG) == CMD_NULL);
 	require(cmd_lookup('{', KEYMAP_MODE_ORIG) == CMD_INSCRIBE);
 	require(cmd_lookup('a', KEYMAP_MODE_ORIG) == CMD_USE_STAFF);
-	require(cmd_lookup('T', KEYMAP_MODE_ORIG) == CMD_TUNNEL);
+	require(cmd_lookup('u', KEYMAP_MODE_ORIG) == CMD_USE);
 	require(cmd_lookup('g', KEYMAP_MODE_ORIG) == CMD_PICKUP);
 	require(cmd_lookup('r', KEYMAP_MODE_ORIG) == CMD_TAKEOFF);
 	require(cmd_lookup('/', KEYMAP_MODE_ORIG) == CMD_ALTER);
@@ -42,7 +42,7 @@ static int test_cmd_lookup_orig(void *state) {
 static int test_cmd_lookup_rogue(void *state) {
 	require(cmd_lookup('{', KEYMAP_MODE_ROGUE) == CMD_INSCRIBE);
 	require(cmd_lookup('a', KEYMAP_MODE_ROGUE) == CMD_USE_STAFF);
-	require(cmd_lookup(KTRL('T'), KEYMAP_MODE_ROGUE) == CMD_TUNNEL);
+	require(cmd_lookup(KTRL('U'), KEYMAP_MODE_ROGUE) == CMD_USE);
 	require(cmd_lookup('g', KEYMAP_MODE_ROGUE) == CMD_PICKUP);
 	require(cmd_lookup('r', KEYMAP_MODE_ROGUE) == CMD_TAKEOFF);
 	require(cmd_lookup('/', KEYMAP_MODE_ROGUE) == CMD_ALTER);
@@ -54,7 +54,7 @@ static int test_cmd_lookup_angband(void *state) {
 	require(cmd_lookup('Z', KEYMAP_MODE_ANGBAND) == CMD_NULL);
 	require(cmd_lookup('{', KEYMAP_MODE_ANGBAND) == CMD_INSCRIBE);
 	require(cmd_lookup('u', KEYMAP_MODE_ANGBAND) == CMD_USE_STAFF);
-	require(cmd_lookup('T', KEYMAP_MODE_ANGBAND) == CMD_TUNNEL);
+	require(cmd_lookup('U', KEYMAP_MODE_ANGBAND) == CMD_USE);
 	require(cmd_lookup('g', KEYMAP_MODE_ANGBAND) == CMD_PICKUP);
 	require(cmd_lookup('t', KEYMAP_MODE_ANGBAND) == CMD_TAKEOFF);
 	require(cmd_lookup('+', KEYMAP_MODE_ANGBAND) == CMD_ALTER);
@@ -65,7 +65,7 @@ static int test_cmd_lookup_angband(void *state) {
 static int test_cmd_lookup_angrogue(void *state) {
 	require(cmd_lookup('{', KEYMAP_MODE_ANGROGUE) == CMD_INSCRIBE);
 	require(cmd_lookup('u', KEYMAP_MODE_ANGROGUE) == CMD_USE_STAFF);
-	require(cmd_lookup(KTRL('T'), KEYMAP_MODE_ANGROGUE) == CMD_TUNNEL);
+	require(cmd_lookup(KTRL('U'), KEYMAP_MODE_ANGROGUE) == CMD_USE);
 	require(cmd_lookup('g', KEYMAP_MODE_ANGROGUE) == CMD_PICKUP);
 	require(cmd_lookup('t', KEYMAP_MODE_ANGROGUE) == CMD_TAKEOFF);
 	require(cmd_lookup('+', KEYMAP_MODE_ANGROGUE) == CMD_ALTER);


### PR DESCRIPTION
CMD_TUNNEL has the same key in all four keysets so it is the less interesting test.  Its tests also checked for KTRL('T') which was wrong since d9325904983c4de5dfcd10cd67bd9828ca0479e1 (and should have generated test failures, but somehow did not).