### PR TITLE
macOS: allow Makefile.osx to add the get-task-allow entitlement - 1.3

### DIFF
--- a/docs/hacking/compiling.rst
+++ b/docs/hacking/compiling.rst
@@ -48,7 +48,7 @@ This will generate a debugging build like that described in the Linux section::
 
     cd src
     make -f Makefile.osx clean
-    make -f Makefile.osx OPT="-g -O1 -fno-omit-frame-pointer -fsanitize=undefined -fsanitize=address"
+    make -f Makefile.osx OPT="-g -O1 -fno-omit-frame-pointer -fsanitize=undefined -fsanitize=address" DEBUGGED_ENTITLEMENT=yes
 
 The clean step is there to clean out object files that were compiled with the
 default options.  The "-g" adds debugging symbols.
@@ -57,7 +57,15 @@ traces that are easier to interpret.  For even clearer call stack traces, you
 could add "-fno-optimize-sibling-calls" to the options or omit optimization
 entirely by replacing "-O1 -fno-omit-frame-pointer" with "-O0".
 "-fsanitize=address -fsanitize=undefined" enables the AddressSanitizer and
-UndefinedBehaviorSanitizer tools.
+UndefinedBehaviorSanitizer tools.  "DEBUGGED_ENTITLEMENT=yes" only has an
+effect with versions of Makefile.osx newer than May 2026 and allows XCode's
+tools to attach to the executable for debugging and tracing (it is not, however,
+currently needed to use the executable with lldb).  If you are using an older
+version of Makefile.osx and are having trouble with XCode's tools failing to
+attach to the executable, see https://github.com/cmyr/cargo-instruments/issues/40#issuecomment-894287229
+for how to sign the executable  so it has the get-task-allow entitlement.
+Because that entitlement allows for code injection, take care about choosing to
+distribute an executable with that entitlement.
 
 To run the generated executable under Xcode's command-line debugger, lldb, do
 this if you are already in the src directory from the compilation step::

--- a/src/Makefile.osx
+++ b/src/Makefile.osx
@@ -10,6 +10,15 @@ CC = clang
 LD = ld
 OPT ?= -O2
 
+# If set and equal to yes, sign the executable with an ad-hoc identity and with
+# the get-task-allow entitlement.  While not currently necessary to run the
+# executable under lldb, that became necessary, at some point between XCode 14.2
+# and XCode 26.2, for the executable to be usable with XCode's Leaks instrument,
+# and likely other debugging or tracing functions within XCode.  Because that
+# entitlement allows code injection, take care about choosing to distribute
+# an executable with that entitlement.
+#DEBUGGED_ENTITLEMENT ?= yes
+
 # for consistency with older versions, use a lower case bundle ID
 BUNDLE_IDENTIFIER = org.rephial.narsil
 
@@ -76,6 +85,10 @@ $(PROGNAME).a: $(OBJS)
 
 $(EXE): $(PROGNAME).a $(OSX_OBJS)
 	$(DEPLOYMENT_TARGET) $(CC) $(CFLAGS) $(LDFLAGS) -o $(EXE) $(OSX_OBJS) $(PROGNAME).a $(LIBS)
+	@if test x"${DEBUGGED_ENTITLEMENT}" = xyes ; then \
+		echo "signing $(EXE) with the get-task-allow entitlement ..." ; \
+		codesign -s - -f --entitlement cocoa/get-task-allow.plist "${EXE}" ; \
+	fi
 
 #
 # Clean up old junk; $(EXE).o and $(addprefix $(EXE).o,$(ARCHS)) are relics

--- a/src/cocoa/get-task-allow.plist
+++ b/src/cocoa/get-task-allow.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding=UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>com.apple.security.get-task-allow</key>
+        <true/>
+    </dict>
+</plist>


### PR DESCRIPTION
It will do so if DEBUGGED_ENTITLEMENT is set to yes.  That entitlement is necessary for some tools in XCode (the Leaks instrument in XCode 26.2 is one) to attach to the executable.  That entitlement is currently not necessary for running the executable under lldb.