### PR TITLE
nds: make button and screen-key strings null-terminated

### DIFF
--- a/src/Makefile.3ds
+++ b/src/Makefile.3ds
@@ -58,7 +58,7 @@ ICON		:=	nds/att-48.png
 #---------------------------------------------------------------------------------
 ARCH	:=	-march=armv6k -mtune=mpcore -mfloat-abi=hard -mtp=soft
 
-CFLAGS	:=	-g -Wall -mword-relocations -ffunction-sections \
+CFLAGS	+=	-g -Wall -mword-relocations -ffunction-sections \
 			$(ARCH)
 
 # Omit some flags for easier debugging

--- a/src/main-nds.c
+++ b/src/main-nds.c
@@ -122,8 +122,6 @@ static nds_pixel color_data[MAX_COLORS];
  */
 static void Term_init_nds(term *t)
 {
-	term_data *td = (term_data *)(t->data);
-
 	/* XXX XXX XXX */
 }
 
@@ -137,8 +135,6 @@ static void Term_init_nds(term *t)
  */
 static void Term_nuke_nds(term *t)
 {
-	term_data *td = (term_data *)(t->data);
-
 	/* XXX XXX XXX */
 }
 
@@ -259,8 +255,6 @@ static void init_color_data(void)
  */
 static errr Term_xtra_nds(int n, int v)
 {
-	term_data *td = (term_data *)(Term->data);
-
 	/* Analyze */
 	switch (n) {
 	case TERM_XTRA_EVENT: {
@@ -433,8 +427,6 @@ static errr Term_curs_nds(int x, int y)
  */
 static errr Term_wipe_nds(int x, int y, int n)
 {
-	term_data *td = (term_data *)(Term->data);
-
 	int i;
 
 	/* Draw a blank */

--- a/src/nds/nds-buttons.c
+++ b/src/nds/nds-buttons.c
@@ -31,7 +31,7 @@ typedef struct {
 } nds_btn_cpad_zone;
 
 typedef struct {
-	char input[NDS_BTN_SEQ_LEN];
+	char input[NDS_BTN_SEQ_LEN + 1];
 	u32 keys;
 } nds_btn_map_entry;
 
@@ -164,7 +164,7 @@ void nds_btn_add_mappings_from_file(ang_file *f) {
 
 		strunescape(sequence);
 
-		strncpy(entry.input, sequence, NDS_BTN_SEQ_LEN);
+		snprintf(entry.input, sizeof(entry.input), "%s", sequence);
 
 		nds_btn_add_mappings(&entry, 1);
 	}
@@ -245,7 +245,7 @@ void nds_btn_vblank()
 		if (!(kd & NDS_BTN_KEYS & keys))
 			continue;
 
-		for (int si = 0; si < NDS_BTN_SEQ_LEN && nds_btn_map[i].input[si]; si++) {
+		for (int si = 0; nds_btn_map[i].input[si]; si++) {
 			nds_event_put_key(nds_btn_map[i].input[si], 0);
 		}
 		break;

--- a/src/nds/nds-screenkeys.c
+++ b/src/nds/nds-screenkeys.c
@@ -24,10 +24,10 @@
 #define CLIP(val, min, max) MAX(MIN(val, max), min)
 
 typedef struct {
-	char label[NDS_SCRKEY_LABEL_LEN];
+	char label[NDS_SCRKEY_LABEL_LEN + 1];
 	uint16_t x, y;
 	uint16_t w, h;
-	char sequence[NDS_SCRKEY_SEQ_LEN];
+	char sequence[NDS_SCRKEY_SEQ_LEN + 1];
 } nds_scrkey_entry;
 
 nds_scrkey_entry *nds_scrkeys = NULL;
@@ -67,7 +67,7 @@ void nds_scrkey_add_file(ang_file *f) {
 
 		nds_scrkey_entry entry = { 0 };
 
-		strncpy(entry.label, label, NDS_SCRKEY_LABEL_LEN);
+		snprintf(entry.label, sizeof(entry.label), "%s", label);
 
 		entry.x = CLIP(strtoul(x_str, NULL, 0), 0, NDS_SCREEN_WIDTH);
 		entry.y = CLIP(strtoul(y_str, NULL, 0), 0, NDS_SCREEN_HEIGHT);
@@ -75,7 +75,7 @@ void nds_scrkey_add_file(ang_file *f) {
 		entry.h = CLIP(strtoul(h_str, NULL, 0), 0, NDS_SCREEN_HEIGHT - entry.y);
 
 		strunescape(sequence);
-		strncpy(entry.sequence, sequence, NDS_SCRKEY_SEQ_LEN);
+		snprintf(entry.sequence, sizeof(entry.sequence), "%s", sequence);
 
 		nds_scrkeys = mem_realloc(nds_scrkeys, (nds_scrkeys_num + 1) * sizeof(nds_scrkey_entry));
 		nds_scrkeys[nds_scrkeys_num++] = entry;
@@ -106,10 +106,10 @@ void nds_scrkey_redraw_key(nds_scrkey_entry *key, bool initial, bool active)
 		}
 	}
 
-	int str_x = key->x + key->w / 2 - strnlen(key->label, NDS_SCRKEY_LABEL_LEN) * nds_font->width / 2;
+	int str_x = key->x + key->w / 2 - strlen(key->label) * nds_font->width / 2;
 	int str_y = NDS_SCREEN_HEIGHT + key->y + key->h / 2 - nds_font->height / 2;
 
-	for (int i = 0; i < NDS_SCRKEY_LABEL_LEN && key->label[i]; i++) {
+	for (int i = 0; key->label[i]; i++) {
 		nds_draw_char_px(str_x + (i * nds_font->width), str_y, key->label[i],
 		                 active ? NDS_CURSOR_COLOR : NDS_WHITE_PIXEL, NDS_BLACK_PIXEL);
 	}
@@ -173,7 +173,7 @@ void nds_scrkey_vblank()
 
 		need_redraw = true;
 
-		for (int si = 0; si < NDS_SCRKEY_SEQ_LEN && entry->sequence[si]; si++) {
+		for (int si = 0; entry->sequence[si]; si++) {
 			nds_event_put_key(entry->sequence[si], 0);
 		}
 


### PR DESCRIPTION
Adjust fixed-size character buffers to include space for a terminating 0, use snprintf(sizeof(...)) for guaranteed termination, and simplify loops to stop on the string terminator. Also replace strnlen() with strlen() where appropriate.

This preserves existing behavior while eliminating warnings exposed by the Nintendo toolchains.