### PR TITLE
correct missing argument casts for is*() functions

### DIFF
--- a/src/datafile.c
+++ b/src/datafile.c
@@ -310,7 +310,7 @@ errr grab_int_range(int *lo, int *hi, const char *range, const char *sep)
 	 * Reject INT_MIN and INT_MAX as well so don't have to check errno in
 	 * order to recognize overflow when sizeof(int) == sizeof(long).
 	 */
-	if (pe == range || !isspace(*pe) || lv1 <= INT_MIN || lv1 >= INT_MAX) {
+	if (pe == range || !isspace((unsigned char)*pe) || lv1 <= INT_MIN || lv1 >= INT_MAX) {
 		return PARSE_ERROR_INVALID_VALUE;
 	}
 	range = pe;
@@ -326,7 +326,7 @@ errr grab_int_range(int *lo, int *hi, const char *range, const char *sep)
 			return PARSE_ERROR_INVALID_VALUE;
 		}
 		range = pe + strlen(sep);
-		if (!isspace(*range)) {
+		if (!isspace((unsigned char)*range)) {
 			return PARSE_ERROR_INVALID_VALUE;
 		}
 	}

--- a/src/obj-util.c
+++ b/src/obj-util.c
@@ -288,7 +288,7 @@ unsigned check_for_inscrip_with_int(const struct object *obj, const char *inscri
 	do {
 		s = strstr(s, inscrip);
 		if (!s) break;
-		if (isdigit(s[inlen])) {
+		if (isdigit((unsigned char)s[inlen])) {
 			if (i == 0) {
 				long inarg = strtol(s + inlen, 0, 10);
 

--- a/src/parser.c
+++ b/src/parser.c
@@ -226,7 +226,7 @@ enum parser_error parser_parse(struct parser *p, const char *line) {
 	p->ftail = NULL;
 
 	/* Ignore empty lines and comments. */
-	while (*line && (isspace(*line)))
+	while (*line && (isspace((unsigned char)*line)))
 		line++;
 	if (!*line || *line == '#')
 		return PARSE_ERROR_NONE;

--- a/src/z-dice.c
+++ b/src/z-dice.c
@@ -334,7 +334,7 @@ bool dice_parse_string(dice_t *dice, const char *string)
 		dice_input_t input_type = DICE_INPUT_MAX;
 
 		/* Skip spaces; this will concatenate digits and variable names. */
-		if (isspace(string[current]))
+		if (isspace((unsigned char)string[current]))
 			continue;
 
 		input_type = dice_input_for_char(string[current]);
@@ -459,7 +459,7 @@ bool dice_parse_string(dice_t *dice, const char *string)
 			int value = 0;
 			bool is_variable = false;
 
-			if (isupper(token[0])) {
+			if (isupper((unsigned char)token[0])) {
 				value = dice_add_variable(dice, token);
 				is_variable = true;
 			}


### PR DESCRIPTION
Avoids warnings on platforms with signed chars.  Ported from Vanilla's https://github.com/angband/angband/commit/f2919f8ce1428ad96b99752d98cacd6c68cd3960 .