### PR TITLE
Correct additional missing casts for is*()'s argument - 1.3

### DIFF
--- a/src/main-gcu.c
+++ b/src/main-gcu.c
@@ -1239,7 +1239,7 @@ static int _parse_size_list(const char *arg, int sizes[], int max)
 
     for (;;)
     {
-        if (!*stop || !isdigit(*stop))
+        if (!*stop || !isdigit((unsigned char)*stop))
         {
             if (i >= max) break;
             if (*start == '*')

--- a/src/main-sdl.c
+++ b/src/main-sdl.c
@@ -3908,7 +3908,7 @@ static errr load_prefs(void)
 		
 		s = strchr(buf, '=');
 		s++;
-		while (!isalnum(*s)) s++;
+		while (!isalnum((unsigned char)*s)) s++;
 		
 		if (strstr(buf, "Resolution")) {
 			screen_w = atoi(s);

--- a/src/tutorial.c
+++ b/src/tutorial.c
@@ -337,7 +337,7 @@ static void tutorial_section_place_custom_door(struct chunk *c, struct loc grid,
 static void append_with_case_sensitive_first(textblock *tb, const char *src,
 		bool capital)
 {
-	if (isupper(src[0])) {
+	if (isupper((unsigned char)src[0])) {
 		if (capital) {
 			textblock_append(tb, "%s", src);
 		} else {

--- a/src/z-dice.c
+++ b/src/z-dice.c
@@ -106,10 +106,10 @@ static dice_input_t dice_input_for_char(char c)
 			break;
 	}
 
-	if (isdigit(c))
+	if (isdigit((unsigned char)c))
 		return DICE_INPUT_DIGIT;
 
-	if (isupper(c))
+	if (isupper((unsigned char)c))
 		return DICE_INPUT_UPPER;
 
 	return DICE_INPUT_MAX;

--- a/src/z-file.c
+++ b/src/z-file.c
@@ -1233,7 +1233,7 @@ bool dir_create(const char *path)
 
 	#ifdef WINDOWS
 	/* If we're on windows, we need to skip past the "C:" part. */
-	if (isalpha(path[0]) && path[1] == ':') path += 2;
+	if (isalpha((unsigned char)path[0]) && path[1] == ':') path += 2;
 	#endif
 
 	/* Iterate through the path looking for path segments. At each step,


### PR DESCRIPTION
The one in tutorial.c is specific to NarSil.  The others were missed in https://github.com/NickMcConnell/NarSil/pull/1093 and its upstream equivalent in Vanilla.