### PR TITLE
unit tests: correct misplaced brace in require() macro - 1.3

### DIFF
--- a/src/tests/unit-test.h
+++ b/src/tests/unit-test.h
@@ -66,8 +66,8 @@ extern int teardown_tests(void *data);
 				showfail(); \
 				printf("    %s:%d: requirement '%s' failed\n", \
 			           suite_name, __LINE__, #x); \
-			return 1; \
 			}  \
+			return 1; \
 		} \
 	} while (0)
 


### PR DESCRIPTION
Caused failing tests using that macro to report as successful when the test was not run in verbose mode.