### PR TITLE
Expand VERSION_NAME rather than use hardwired "Angband" in two error messages - 1.3

### DIFF
--- a/src/main-gcu.c
+++ b/src/main-gcu.c
@@ -1322,7 +1322,8 @@ errr init_gcu(int argc, char **argv) {
 
 	/* Require standard size screen */
 	if (LINES < MIN_TERM0_LINES || COLS < MIN_TERM0_COLS) 
-		quit("Angband needs at least an 80x24 'curses' screen");
+		quit_fmt("%s needs at least an 80x24 'curses' screen",
+			VERSION_NAME);
 
 #ifdef A_COLOR
 	/* Do we have color, and enough color, available? */

--- a/src/main.c
+++ b/src/main.c
@@ -17,6 +17,7 @@
  */
 
 #include "angband.h"
+#include "buildid.h"
 #include "init.h"
 #include "savefile.h"
 #include "ui-birth.h"
@@ -479,7 +480,7 @@ int main(int argc, char *argv[])
 	if (setlocale(LC_CTYPE, "")) {
 		/* Require UTF-8 */
 		if (!streq(nl_langinfo(CODESET), "UTF-8"))
-			quit("Angband requires UTF-8 support");
+			quit_fmt("%s requires UTF-8 support", VERSION_NAME);
 	}
 #endif
 


### PR DESCRIPTION
That is to be friendlier to variants.