### PR TITLE
Delay expanding user-supplied history notes

### DIFF
--- a/src/cmd-misc.c
+++ b/src/cmd-misc.c
@@ -130,36 +130,26 @@ void do_cmd_retire(struct command *cmd)
  * Record the player's thoughts as a note.
  *
  * This both displays the note back to the player and adds it to the game log.
- * Two fancy note types are supported: notes beginning with "/say" will be
- * written as 'Frodo says: "____"', and notes beginning with "/me" will
- * be written as 'Frodo ____'.
+ * If the note begins with "/" followed by specific strings, those will be
+ * expanded when the history is viewed.  See history_expand_user_input()'s
+ * documentation for details about that.
  */
 void do_cmd_note(void)
 {
-	/* Allocate/Initialize strings to get and format user input. */
-	char tmp[70];
-	char note[90];
-	my_strcpy(tmp, "", sizeof(tmp));
-	my_strcpy(note, "", sizeof(note));
+	char note[80] = "";
 
 	/* Read a line of input from the user */
-	if (!get_string("Note: ", tmp, sizeof(tmp))) return;
+	if (!get_string("Note: ", note, sizeof(note))) return;
 
 	/* Ignore empty notes */
-	if (!tmp[0] || (tmp[0] == ' ')) return;
+	if (!note[0] || (note[0] == ' ')) return;
 
-	/* Format the note correctly, supporting some cute /me commands */
-	if (strncmp(tmp, "/say ", 5) == 0)
-		strnfmt(note, sizeof(note), "-- %s says: \"%s\"", player->full_name,
-				&tmp[5]);
-	else if (strncmp(tmp, "/me", 3) == 0)
-		strnfmt(note, sizeof(note), "-- %s%s", player->full_name, &tmp[3]);
-	else
-		strnfmt(note, sizeof(note), "-- Note: %s", tmp);
-
-	/* Display the note (omitting the "-- " prefix) */
-	msg("%s", &note[3]);
-
-	/* Add a history entry */
+	/* Add a history entry, with the user's text as is */
 	history_add(player, note, HIST_USER_INPUT);
+
+	/*
+	 * Provide feedback with the note expanded, except for a "-- " prefix,
+	 * as it will be when the history is displayed.
+	 */
+	msg(history_expand_user_input(note, player, NULL, 0, false));
 }

--- a/src/player-history.c
+++ b/src/player-history.c
@@ -290,3 +290,44 @@ size_t history_get_list(struct player *p, struct history_info **list)
 	*list = h->entries;
 	return h->next;
 }
+
+/**
+ * Expand a user-supplied note in the history.
+ *
+ * \param note is the text of the note.
+ * \param p points to the player who made the note.
+ * \param buf is the buffer to hold the expanded note.  May be NULL, in which
+ * case a static buffer will be used.
+ * \param len is the length of buf.  It is ignored if buf is NULL.  For a note
+ * which is at most n (currently 80 for struct history_info's event field)
+ * character long, a buffer with at least PLAYER_NAME_LEN + 6 + n characters
+ * including the terminating NULL will hold the expanded note without
+ * truncation.
+ * \param use_prefix will, if true, prepend the expanded note with "-- ".
+ * \return to the pointer to the beginning of the expanded note.
+ *
+ * Notes that begin with "/say " will have that replaced by 'x says: "' where
+ * x is p->full_name and will have a double quote appended to the end of the
+ * note.  Notes that begin with "/me" will have that replaced by p->full_name.
+ * All others will have the text of the note prepended with "Note: ".
+ */
+const char *history_expand_user_input(const char *note, const struct player *p,
+		char *buf, size_t len, bool use_prefix)
+{
+	static char sbuf[PLAYER_NAME_LEN + 86];
+	const char *defp = (use_prefix) ? "-- " : "";
+
+	if (!buf) {
+		buf = sbuf;
+		len = N_ELEMENTS(sbuf);
+	}
+	if (prefix(note, "/say ")) {
+		(void)strnfmt(buf, len, "%s%s says: \"%s\"", defp, p->full_name,
+			note + 5);
+	} else if (prefix(note, "/me")) {
+		(void)strnfmt(buf, len, "%s%s%s", defp, p->full_name, note + 3);
+	} else {
+		(void)strnfmt(buf, len, "%sNote: %s", defp, note);
+	}
+	return buf;
+}

--- a/src/player-history.h
+++ b/src/player-history.h
@@ -65,5 +65,7 @@ void history_find_artifact(struct player *p, const struct artifact *artifact);
 void history_lose_artifact(struct player *p, const struct artifact *artifact);
 void history_unmask_unknown(struct player *p);
 size_t history_get_list(struct player *p, struct history_info **list);
+const char *history_expand_user_input(const char *note, const struct player *p,
+		char *buf, size_t len, bool prefix);
 
 #endif /* !HISTORY_H */

--- a/src/ui-history.c
+++ b/src/ui-history.c
@@ -40,7 +40,7 @@ void history_display(void)
 	struct history_info *history_list_local = NULL;
 	size_t max_item = history_get_list(player, &history_list_local);
 	int row, wid, hgt, page_size;
-	char buf[120];
+	char buf[PLAYER_NAME_LEN + 106];
 	static size_t first_item = 0;
 	size_t i;
 	bool active = true;
@@ -67,7 +67,12 @@ void history_display(void)
 			strnfmt(buf, sizeof(buf), "%10ld%7d\'  %s",
 				(long)history_list_local[i].turn,
 				history_list_local[i].dlev * 50,
-				history_list_local[i].event);
+				(!hist_has(history_list_local[i].type,
+				HIST_USER_INPUT))
+				? history_list_local[i].event
+				: history_expand_user_input(
+				history_list_local[i].event, player, NULL, 0,
+				true));
 
 			if (hist_has(history_list_local[i].type, HIST_ARTIFACT_LOST))
 				my_strcat(buf, " (LOST)", sizeof(buf));
@@ -130,16 +135,19 @@ void dump_history(ang_file *file)
 	struct history_info *history_list_local = NULL;
 	size_t max_item = history_get_list(player, &history_list_local);
 	size_t i;
-	char buf[120];
+	char buf[PLAYER_NAME_LEN + 106];
 
 	file_putf(file, "[Player history]\n");
 	file_putf(file, "      Turn   Depth  Note\n");
 
 	for (i = 0; i < max_item; i++) {
 		strnfmt(buf, sizeof(buf), "%10ld%7d\'  %s",
-				(long)history_list_local[i].turn,
-				history_list_local[i].dlev * 50,
-				history_list_local[i].event);
+			(long)history_list_local[i].turn,
+			history_list_local[i].dlev * 50,
+			(!hist_has(history_list_local[i].type, HIST_USER_INPUT))
+			? history_list_local[i].event
+			: history_expand_user_input(history_list_local[i].event,
+			player, NULL, 0, true));
 
 		if (hist_has(history_list_local[i].type, HIST_ARTIFACT_LOST))
 			my_strcat(buf, " (LOST)", sizeof(buf));


### PR DESCRIPTION
This is an alternate solution to avoiding truncated notes, noted by fruviad in https://github.com/angband/angband/pull/6656 .